### PR TITLE
docs: correct presenters directory name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ Workshop Content:
 ### Asset Management
 - **Images**: Stored in `public/images/` with organized subdirectories
 - **Optimization**: All images use Next.js Image component
-- **Structure**: `presentors/`, `mechanisms/`, `hardware/` folders
+- **Structure**: `presenters/`, `mechanisms/`, `hardware/` folders
 
 ### Development Patterns
 - **File Naming**: kebab-case for routes, PascalCase for components


### PR DESCRIPTION
## Summary
- fix presenters directory spelling in Asset Management section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b89b9e8b548332ad51345b40ce0b90