### PR TITLE
docs: update contributing clone instructions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,8 +13,8 @@ Thank you for your interest in contributing to the Gray Matter Coding Workshop w
 
 1. **Fork and clone the repository**
    ```bash
-   git clone https://github.com/yourusername/gray-matter-workshop.git
-   cd gray-matter-workshop
+   git clone https://github.com/yourusername/Workshop-Site.git
+   cd Workshop-Site
    ```
 
 2. **Install dependencies**


### PR DESCRIPTION
## Summary
- point contributing docs to Workshop-Site repo for cloning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b89ba1ccd08332a5ec4c3406ce01ba