### PR TITLE
Remove PR number references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,12 +96,12 @@ Workshop Content:
 
 ### Workshop-Code Integration & Implementation Steps (Latest)
 - **Repository Integration**: Connected site to Workshop-Code repository for live code examples
-- **5-Step Learning Progression**: Implemented structured approach following PR workflow:
-  1. **Basic Subsystem (PR #1)**: Motor control and sensor integration
-  2. **Commands Integration (PR #2)**: Command-based architecture and user input
-  3. **PID Control (PR #3)**: Precise position control with feedback loops
-  4. **Motion Magic (PR #4)**: Smooth profiled movements with acceleration control
-  5. **Useful Functions (PR #5)**: Safety features, utilities, and diagnostics
+- **5-Step Learning Progression**: Implemented structured approach following development workflow:
+  1. **Basic Subsystem**: Motor control and sensor integration
+  2. **Commands Integration**: Command-based architecture and user input
+  3. **PID Control**: Precise position control with feedback loops
+  4. **Motion Magic**: Smooth profiled movements with acceleration control
+  5. **Useful Functions**: Safety features, utilities, and diagnostics
 - **Educational Enhancement**: Added detailed explanations, visual learning aids, and practical implementation details
 - **Real-World Context**: Each step explains both technical implementation and competition relevance
 

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ The workshop includes live code examples from the companion repository:
 **[Workshop-Code](https://github.com/Hemlock5712/Workshop-Code)**
 
 ### Implementation Progression
-The workshop follows a structured 5-step progression through pull requests:
+The workshop follows a structured 5-step progression:
 
-1. **PR #1: Creating a Subsystem** - Basic motor control and sensor integration
-2. **PR #2: Adding Commands** - Command-based architecture and user input
-3. **PR #3: PID Control** - Precise position control with feedback loops
-4. **PR #4: Using Motion Magic** - Smooth profiled movements with acceleration control
-5. **PR #5: Useful Subsystem Functions** - Safety features, utilities, and diagnostics
+1. **Step 1: Creating a Subsystem** - Basic motor control and sensor integration
+2. **Step 2: Adding Commands** - Command-based architecture and user input
+3. **Step 3: PID Control** - Precise position control with feedback loops
+4. **Step 4: Using Motion Magic** - Smooth profiled movements with acceleration control
+5. **Step 5: Useful Subsystem Functions** - Safety features, utilities, and diagnostics
 
 Each step builds upon the previous implementation, showing real-world development practices.
 

--- a/src/app/pid-control/page.tsx
+++ b/src/app/pid-control/page.tsx
@@ -5,7 +5,7 @@ import CodeBlock from "@/components/CodeBlock";
 export default function PIDControl() {
   return (
     <PageTemplate
-      title="PID Control (PR #3)"
+      title="PID Control"
       previousPage={{ href: "/mechanism-setup", title: "Mechanism Setup" }}
       nextPage={{ href: "/motion-magic", title: "Motion Magic" }}
     >
@@ -175,12 +175,12 @@ public void setTargetPosition(double positionRotations) {
         {/* Before/After Implementation */}
         <div className="bg-slate-50 dark:bg-slate-800 rounded-lg p-6">
           <h3 className="text-xl font-bold text-slate-900 dark:text-slate-100 mb-4">
-            🔄 Before → After: PR #3 Implementation
+            🔄 Before → After: PID Control Implementation
           </h3>
           
           <div className="grid md:grid-cols-2 gap-6">
             <div className="bg-red-50 dark:bg-red-950/30 p-4 rounded-lg border border-red-200 dark:border-red-900">
-              <h4 className="font-bold text-focus-700 dark:text-focus-300 mb-2">📋 Before (PR #2)</h4>
+              <h4 className="font-bold text-focus-700 dark:text-focus-300 mb-2">📋 Before</h4>
               <ul className="text-sm text-red-800 dark:text-red-300 space-y-1">
                 <li>• Commands control ARM with voltage</li>
                 <li>• No position feedback control</li>
@@ -191,7 +191,7 @@ public void setTargetPosition(double positionRotations) {
             </div>
 
             <div className="bg-learn-50 dark:bg-learn-950/30 p-4 rounded-lg border border-green-200 dark:border-green-900">
-              <h4 className="font-bold text-learn-700 dark:text-learn-300 mb-2">✅ After (PR #3)</h4>
+              <h4 className="font-bold text-learn-700 dark:text-learn-300 mb-2">✅ After</h4>
               <ul className="text-sm text-learn-800 dark:text-learn-300 space-y-1">
                 <li>• PID position control with PositionVoltage</li>
                 <li>• Automatic target position reaching</li>

--- a/src/app/programming/page.tsx
+++ b/src/app/programming/page.tsx
@@ -153,7 +153,7 @@ export default function Programming() {
 
         <div className="bg-green-50 dark:bg-green-950/30 border border-green-200 dark:border-green-900 rounded-lg p-6">
           <h3 className="text-xl font-bold text-learn-700 dark:text-learn-300 mb-4">
-            🎮 Step 2: Commands Integration (PR #2)
+            🎮 Step 2: Commands Integration
           </h3>
           <p className="text-green-800 dark:text-green-300 mb-4">
             Now we add command-based control, allowing user input to control our ARM mechanism.
@@ -197,7 +197,7 @@ export default function Programming() {
 
         <div className="bg-purple-50 dark:bg-purple-950/30 border border-purple-200 dark:border-purple-900 rounded-lg p-6">
           <h3 className="text-xl font-bold text-concept-700 dark:text-concept-300 mb-4">
-            🎯 Step 3: PID Control (PR #3)
+            🎯 Step 3: PID Control
           </h3>
           <p className="text-purple-800 dark:text-purple-300 mb-4">
             Replace voltage control with precise PID position control for accurate, repeatable movements.

--- a/src/components/GitHubPR.tsx
+++ b/src/components/GitHubPR.tsx
@@ -136,7 +136,7 @@ export default function GitHubPR({
             {error || "PR not found"}
           </p>
           <p className="text-red-600 dark:text-red-400 text-sm mt-2">
-            Repository: {repository}, PR #{pullRequestNumber}
+            Repository: {repository}
           </p>
         </div>
       </div>
@@ -264,9 +264,6 @@ export default function GitHubPR({
                     : pr.state === "closed"
                     ? "❌ Closed"
                     : "🔄 Open"}
-                </span>
-                <span className="text-gray-500 dark:text-gray-400 text-sm">
-                  #{pr.number}
                 </span>
               </div>
 


### PR DESCRIPTION
## Summary
- Eliminate explicit PR number references from docs and pages
- Remove PR number display from GitHubPR component
- Clean up development notes to omit PR identifiers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b89cb94b288332a101bb30a0c722ff