### PR TITLE
fix: match adding-commands intro gradient to meet-the-team style

### DIFF
--- a/src/app/adding-commands/page.tsx
+++ b/src/app/adding-commands/page.tsx
@@ -10,7 +10,7 @@ export default function AddingCommands() {
       nextPage={{ href: "/mechanism-setup", title: "Mechanism Setup" }}
     >
       {/* Introduction */}
-      <div className="bg-gradient-to-r from-concept-50 to-practice-50 dark:from-concept-950/30 dark:to-practice-950/30 rounded-lg p-8 border border-[var(--border)]">
+      <div className="bg-gradient-to-r from-primary-50 to-concept-50 dark:from-primary-950/30 dark:to-concept-950/30 rounded-lg p-8 border border-[var(--border)]">
           <h2 className="text-2xl font-bold text-[var(--foreground)] mb-4">
           Command-Based Programming
         </h2>


### PR DESCRIPTION
## Summary
- use Meet-the-Team gradient for the Adding Commands intro section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b8a257ab30833280481f8fa36a7dfd