### PR TITLE
style: adjust gradient colors for GitHub components

### DIFF
--- a/src/components/GitHubPR.tsx
+++ b/src/components/GitHubPR.tsx
@@ -366,7 +366,7 @@ export default function GitHubPR({
       </div>
 
       {/* Workshop Context */}
-      <div className="bg-gradient-to-r from-primary-50 to-concept-50 dark:from-primary-900/20 dark:to-concept-900/20 rounded-lg p-6">
+        <div className="bg-gradient-to-r from-primary-50 to-concept-50 dark:from-primary-950/30 dark:to-concept-950/30 rounded-lg p-6">
         <h5 className="font-semibold text-[var(--foreground)] mb-3">
           🎓 Workshop Learning
         </h5>

--- a/src/components/GitHubPage.tsx
+++ b/src/components/GitHubPage.tsx
@@ -200,7 +200,7 @@ export default function GitHubPage({
       </div>
 
       {/* GitHub Context */}
-      <div className="bg-gradient-to-r from-primary-50 to-concept-50 dark:from-primary-900/20 dark:to-concept-900/20 rounded-lg p-6">
+        <div className="bg-gradient-to-r from-primary-50 to-concept-50 dark:from-primary-950/30 dark:to-concept-950/30 rounded-lg p-6">
         <h5 className="font-semibold text-[var(--foreground)] mb-3">
           📁 Live from GitHub
         </h5>


### PR DESCRIPTION
## Summary
- refine GitHub page/pr gradients for improved dark theme contrast

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b8a27b9474833281f0a9a47b4fa9f1