### PR TITLE
refactor: replace gradient backgrounds with theme tokens

### DIFF
--- a/src/app/adding-commands/page.tsx
+++ b/src/app/adding-commands/page.tsx
@@ -10,13 +10,11 @@ export default function AddingCommands() {
       nextPage={{ href: "/mechanism-setup", title: "Mechanism Setup" }}
     >
       {/* Introduction */}
-      <div className="bg-gradient-to-r from-primary-50 to-concept-50 dark:from-primary-950/30 dark:to-concept-950/30 rounded-lg p-8 border border-[var(--border)]">
-          <h2 className="text-2xl font-bold text-[var(--foreground)] mb-4">
-          Command-Based Programming
-        </h2>
-          <p className="text-[var(--muted-foreground)] mb-4">
-          Commands are the &quot;actions&quot; that your robot performs. They use subsystems to accomplish tasks 
-          and can be triggered by user input, sensors, or automated sequences.
+      <div className="bg-[var(--card)] text-[var(--foreground)] rounded-lg p-8 border border-[var(--border)]">
+        <h2 className="text-2xl font-bold mb-4">Command-Based Programming</h2>
+        <p className="text-[var(--muted-foreground)] mb-4">
+          Commands are the &quot;actions&quot; that your robot performs. They use subsystems to accomplish tasks and can be triggered
+          by user input, sensors, or automated sequences.
         </p>
         <div className="bg-learn-100 dark:bg-learn-900/30 p-4 rounded-lg">
           <p className="text-learn-800 dark:text-learn-300 font-medium">

--- a/src/app/building-subsystems/page.tsx
+++ b/src/app/building-subsystems/page.tsx
@@ -10,13 +10,11 @@ export default function BuildingSubsystems() {
       nextPage={{ href: "/adding-commands", title: "Commands" }}
     >
       {/* Introduction */}
-      <div className="bg-gradient-to-r from-primary-50 to-concept-50 dark:from-primary-950/30 dark:to-concept-950/30 rounded-lg p-8 border border-slate-200 dark:border-slate-800">
-        <h2 className="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-4">
-          Understanding Subsystems
-        </h2>
-        <p className="text-slate-600 dark:text-slate-300 mb-4">
-          Subsystems are the foundation of command-based programming. They represent physical hardware components 
-          and provide methods to control them safely and effectively.
+      <div className="bg-[var(--card)] text-[var(--foreground)] rounded-lg p-8 border border-[var(--border)]">
+        <h2 className="text-2xl font-bold mb-4">Understanding Subsystems</h2>
+        <p className="mb-4">
+          Subsystems are the foundation of command-based programming. They represent physical hardware components and provide
+          methods to control them safely and effectively.
         </p>
         <div className="bg-primary-100 dark:bg-primary-900/30 p-4 rounded-lg">
           <p className="text-primary-800 dark:text-primary-300 font-medium">

--- a/src/app/mechanism-setup/page.tsx
+++ b/src/app/mechanism-setup/page.tsx
@@ -9,14 +9,12 @@ export default function MechanismSetup() {
       nextPage={{ href: "/pid-control", title: "PID Control" }}
     >
       {/* Introduction */}
-        <div className="bg-gradient-to-r from-primary-50 to-concept-50 dark:from-primary-950/30 dark:to-concept-950/30 rounded-lg p-8 border border-[var(--border)]">
-          <h2 className="text-2xl font-bold text-[var(--foreground)] mb-4">
-          Verifying Your Mechanism Setup
-        </h2>
+        <div className="bg-[var(--card)] text-[var(--foreground)] rounded-lg p-8 border border-[var(--border)]">
+          <h2 className="text-2xl font-bold mb-4">Verifying Your Mechanism Setup</h2>
           <p className="text-[var(--muted-foreground)] mb-4">
-          Before implementing advanced control algorithms, we need to verify that motors and encoders are working correctly. 
-          This ensures proper direction, zeroing, and basic functionality.
-        </p>
+            Before implementing advanced control algorithms, we need to verify that motors and encoders are working correctly.
+            This ensures proper direction, zeroing, and basic functionality.
+          </p>
         <div className="bg-focus-100 dark:bg-focus-900/30 p-4 rounded-lg">
           <p className="text-focus-800 dark:text-focus-300 font-medium">
             🔍 Key Concept: Always verify hardware setup before adding control algorithms - this prevents debugging control issues when the problem is hardware configuration
@@ -71,11 +69,9 @@ export default function MechanismSetup() {
           <h3 className="text-xl font-bold text-learn-600 mb-4">🔧 Motor Direction Verification</h3>
           
           <div className="grid md:grid-cols-2 gap-6">
-            <div className="bg-gradient-to-r from-primary-50 to-concept-50 dark:from-primary-950/30 dark:to-concept-950/30 p-6 rounded-lg">
-              <h4 className="font-semibold text-learn-900 dark:text-learn-300 mb-3">Positive Voltage Test</h4>
-              <p className="text-learn-800 dark:text-learn-300 text-sm mb-3">
-                Apply +6V to your motor and observe movement direction.
-              </p>
+            <div className="bg-[var(--card)] text-[var(--foreground)] p-6 rounded-lg">
+              <h4 className="font-semibold mb-3">Positive Voltage Test</h4>
+              <p className="text-sm mb-3">Apply +6V to your motor and observe movement direction.</p>
               <div className="bg-[var(--muted)] text-[var(--muted-foreground)] p-3 rounded border border-[var(--border)]">
                 <p className="text-xs text-[var(--muted-foreground)]">
                   <strong>Expected:</strong> Positive voltage should move the mechanism in the &quot;positive&quot; direction (counter-clockwise for arms, out for extensions, and up for elevators).
@@ -83,11 +79,9 @@ export default function MechanismSetup() {
               </div>
             </div>
 
-            <div className="bg-gradient-to-r from-primary-50 to-concept-50 dark:from-primary-950/30 dark:to-concept-950/30 p-6 rounded-lg">
-              <h4 className="font-semibold text-focus-900 dark:text-focus-300 mb-3">Encoder Consistency</h4>
-              <p className="text-focus-800 dark:text-focus-300 text-sm mb-3">
-                Verify encoder readings match motor movement.
-              </p>
+            <div className="bg-[var(--card)] text-[var(--foreground)] p-6 rounded-lg">
+              <h4 className="font-semibold mb-3">Encoder Consistency</h4>
+              <p className="text-sm mb-3">Verify encoder readings match motor movement.</p>
               <div className="bg-[var(--muted)] text-[var(--muted-foreground)] p-3 rounded border border-[var(--border)]">
                 <p className="text-xs text-[var(--muted-foreground)]">
                   <strong>Expected:</strong> Positive motor voltage → positive encoder change, negative motor voltage → negative encoder change.
@@ -98,16 +92,16 @@ export default function MechanismSetup() {
         </div>
 
         {/* Zero Encoder Setup */}
-        <div className="bg-gradient-to-r from-primary-50 to-concept-50 dark:from-primary-950/30 dark:to-concept-950/30 border border-[var(--border)] rounded-lg p-6">
-          <h3 className="text-xl font-bold text-concept-700 dark:text-concept-300 mb-4">🎯 Zero Encoder Position</h3>
-          
+        <div className="bg-[var(--card)] text-[var(--foreground)] border border-[var(--border)] rounded-lg p-6">
+          <h3 className="text-xl font-bold mb-4">🎯 Zero Encoder Position</h3>
+
           <div className="grid md:grid-cols-2 gap-6 mb-6">
             <div>
-              <p className="text-concept-800 dark:text-concept-300 mb-4">
+              <p className="mb-4">
                 Set your mechanism to the zero position before running any control algorithms. For Arm mechanisms,
                 zero should be straight parallel with the ground, facing the 3 o&apos;clock position.
               </p>
-              
+
               <div className="bg-concept-100 dark:bg-concept-900/30 p-4 rounded-lg">
                 <h4 className="font-semibold text-concept-900 dark:text-concept-300 mb-2">Zero Position Setup:</h4>
                 <ul className="text-concept-800 dark:text-concept-300 space-y-1 text-sm">

--- a/src/app/pid-control/page.tsx
+++ b/src/app/pid-control/page.tsx
@@ -10,14 +10,12 @@ export default function PIDControl() {
       nextPage={{ href: "/motion-magic", title: "Motion Magic" }}
     >
       {/* Introduction */}
-        <div className="bg-gradient-to-r from-primary-50 to-concept-50 dark:from-primary-950/30 dark:to-concept-950/30 rounded-lg p-8 border border-[var(--border)]">
-          <h2 className="text-2xl font-bold text-[var(--foreground)] mb-4">
-          PID Control - Precise Position Control
-        </h2>
+        <div className="bg-[var(--card)] text-[var(--foreground)] rounded-lg p-8 border border-[var(--border)]">
+          <h2 className="text-2xl font-bold mb-4">PID Control - Precise Position Control</h2>
           <p className="text-[var(--muted-foreground)] mb-4">
-          PID (Proportional-Integral-Derivative) control replaces imprecise voltage commands with accurate, 
-          feedback-driven position control. Essential for mechanisms that need to hit specific targets.
-        </p>
+            PID (Proportional-Integral-Derivative) control replaces imprecise voltage commands with accurate, feedback-driven
+            position control. Essential for mechanisms that need to hit specific targets.
+          </p>
         <div className="bg-red-100 dark:bg-red-900/30 p-4 rounded-lg">
           <p className="text-red-800 dark:text-red-300 font-medium">
             🎯 Key Concept: PID uses sensor feedback to automatically adjust motor output to reach and maintain target positions

--- a/src/components/GitHubPage.tsx
+++ b/src/components/GitHubPage.tsx
@@ -200,10 +200,8 @@ export default function GitHubPage({
       </div>
 
       {/* GitHub Context */}
-        <div className="bg-gradient-to-r from-primary-50 to-concept-50 dark:from-primary-950/30 dark:to-concept-950/30 rounded-lg p-6">
-        <h5 className="font-semibold text-[var(--foreground)] mb-3">
-          📁 Live from GitHub
-        </h5>
+      <div className="bg-[var(--card)] text-[var(--foreground)] rounded-lg p-6">
+        <h5 className="font-semibold mb-3">📁 Live from GitHub</h5>
         <p className="text-[var(--muted-foreground)] text-sm">
           This file is displayed directly from the GitHub repository. Click
           &quot;View on GitHub&quot; to see the file in its repository context,


### PR DESCRIPTION
## Summary
- replace gradient backgrounds with card color and default foreground text
- update motor verification callouts to use neutral card styling
- align GitHub context panel with theme tokens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b8a777182c8332871861789e40b6d3