### PR TITLE
Use neutral scheme for callout boxes

### DIFF
--- a/src/app/motion-magic/page.tsx
+++ b/src/app/motion-magic/page.tsx
@@ -18,8 +18,8 @@ export default function MotionMagic() {
           Motion Magic builds on PID control by adding smooth acceleration and deceleration profiles. 
           This prevents jerky movements and reduces mechanical stress while maintaining precise positioning.
         </p>
-        <div className="bg-concept-100 dark:bg-concept-900/30 p-4 rounded-lg">
-          <p className="text-concept-800 dark:text-concept-300 font-medium">
+        <div className="bg-[var(--muted)] p-4 rounded-lg border-l-4 border-purple-500">
+          <p className="text-[var(--foreground)] font-medium">
             🚀 Key Concept: Motion Magic automatically generates smooth velocity profiles to reach target positions with controlled acceleration
           </p>
         </div>
@@ -32,45 +32,45 @@ export default function MotionMagic() {
         </h2>
 
         <div className="grid md:grid-cols-2 gap-6">
-          <div className="bg-concept-50 dark:bg-concept-950/30 rounded-lg p-6 border border-concept-200 dark:border-concept-900">
-            <h3 className="text-xl font-bold text-concept-700 dark:text-concept-300 mb-4">📈 Trapezoidal Profile</h3>
-            <p className="text-concept-800 dark:text-concept-300 mb-4 text-sm">
+          <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-purple-500">
+            <h3 className="text-xl font-bold text-[var(--foreground)] mb-4">📈 Trapezoidal Profile</h3>
+            <p className="text-[var(--foreground)] mb-4 text-sm">
               Motion Magic creates a trapezoidal velocity profile with three phases:
             </p>
             <div className="space-y-2">
               <div className="bg-slate-50 dark:bg-slate-900 p-3 rounded">
-                <strong className="text-concept-700 dark:text-concept-300">1. Acceleration:</strong>
-                <span className="text-concept-600 dark:text-concept-400 text-sm"> Ramp up to cruise velocity</span>
+                <strong className="text-[var(--foreground)]">1. Acceleration:</strong>
+                <span className="text-[var(--muted-foreground)] text-sm"> Ramp up to cruise velocity</span>
               </div>
               <div className="bg-slate-50 dark:bg-slate-900 p-3 rounded">
-                <strong className="text-concept-700 dark:text-concept-300">2. Cruise:</strong>
-                <span className="text-concept-600 dark:text-concept-400 text-sm"> Maintain constant max velocity</span>
+                <strong className="text-[var(--foreground)]">2. Cruise:</strong>
+                <span className="text-[var(--muted-foreground)] text-sm"> Maintain constant max velocity</span>
               </div>
               <div className="bg-slate-50 dark:bg-slate-900 p-3 rounded">
-                <strong className="text-concept-700 dark:text-concept-300">3. Deceleration:</strong>
-                <span className="text-concept-600 dark:text-concept-400 text-sm"> Smoothly brake to target</span>
+                <strong className="text-[var(--foreground)]">3. Deceleration:</strong>
+                <span className="text-[var(--muted-foreground)] text-sm"> Smoothly brake to target</span>
               </div>
             </div>
           </div>
 
-          <div className="bg-primary-50 dark:bg-primary-950/30 rounded-lg p-6 border border-blue-200 dark:border-blue-900">
-            <h3 className="text-xl font-bold text-primary-700 dark:text-primary-300 mb-4">⚙️ Key Parameters</h3>
+          <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-blue-500">
+            <h3 className="text-xl font-bold text-[var(--foreground)] mb-4">⚙️ Key Parameters</h3>
             <div className="space-y-3">
               <div className="bg-slate-50 dark:bg-slate-900 p-3 rounded">
-                <h4 className="font-bold text-primary-700 dark:text-primary-300">Motion Magic Cruise Velocity</h4>
-                <p className="text-primary-600 dark:text-primary-400 text-sm">
+                <h4 className="font-bold text-[var(--foreground)]">Motion Magic Cruise Velocity</h4>
+                <p className="text-[var(--muted-foreground)] text-sm">
                   Maximum velocity during cruise phase (rotations/second)
                 </p>
               </div>
               <div className="bg-slate-50 dark:bg-slate-900 p-3 rounded">
-                <h4 className="font-bold text-primary-700 dark:text-primary-300">Motion Magic Acceleration</h4>
-                <p className="text-primary-600 dark:text-primary-400 text-sm">
+                <h4 className="font-bold text-[var(--foreground)]">Motion Magic Acceleration</h4>
+                <p className="text-[var(--muted-foreground)] text-sm">
                   Rate of acceleration/deceleration (rotations/second²)
                 </p>
               </div>
               <div className="bg-slate-50 dark:bg-slate-900 p-3 rounded">
-                <h4 className="font-bold text-primary-700 dark:text-primary-300">Motion Magic Jerk</h4>
-                <p className="text-primary-600 dark:text-primary-400 text-sm">
+                <h4 className="font-bold text-[var(--foreground)]">Motion Magic Jerk</h4>
+                <p className="text-[var(--muted-foreground)] text-sm">
                   Rate of change of acceleration (rotations/second³)
                 </p>
               </div>
@@ -79,9 +79,9 @@ export default function MotionMagic() {
         </div>
 
         {/* Documentation Link */}
-        <div className="bg-indigo-50 dark:bg-indigo-950/30 border border-indigo-200 dark:border-indigo-900 rounded-lg p-6">
-          <h3 className="text-xl font-bold text-primary-700 dark:text-primary-300 mb-4">📚 Official Motion Magic Documentation</h3>
-          <p className="text-indigo-800 dark:text-indigo-300 mb-4">
+        <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-purple-500">
+          <h3 className="text-xl font-bold text-[var(--foreground)] mb-4">📚 Official Motion Magic Documentation</h3>
+          <p className="text-[var(--foreground)] mb-4">
             For complete Motion Magic reference, configuration examples, and advanced tuning techniques:
           </p>
           <a 
@@ -153,9 +153,9 @@ public void setTargetPosition(double positionRotations) {
           </h3>
           
           <div className="grid md:grid-cols-2 gap-6">
-            <div className="bg-red-50 dark:bg-red-950/30 p-4 rounded-lg border border-red-200 dark:border-red-900">
-              <h4 className="font-bold text-red-700 dark:text-red-300 mb-2">📋 Before</h4>
-              <ul className="text-sm text-red-800 dark:text-red-300 space-y-1">
+            <div className="bg-[var(--muted)] p-4 rounded-lg border-l-4 border-red-500">
+              <h4 className="font-bold text-[var(--foreground)] mb-2">📋 Before</h4>
+              <ul className="text-sm text-[var(--foreground)] space-y-1">
                 <li>• PID position control with PositionVoltage</li>
                 <li>• Instant acceleration to target</li>
                 <li>• Potential mechanical stress from jerky movements</li>
@@ -219,12 +219,12 @@ public void setTargetPosition(double positionRotations) {
         </div>
 
         {/* Motion Magic vs PID Comparison */}
-        <div className="bg-yellow-50 dark:bg-yellow-950/30 border border-yellow-200 dark:border-yellow-900 rounded-lg p-6">
-          <h3 className="text-xl font-bold text-focus-700 dark:text-focus-300 mb-4">⚖️ Motion Magic vs Basic PID</h3>
+        <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-yellow-500">
+          <h3 className="text-xl font-bold text-[var(--foreground)] mb-4">⚖️ Motion Magic vs Basic PID</h3>
           <div className="grid md:grid-cols-2 gap-6">
             <div>
-              <h4 className="font-semibold text-yellow-800 dark:text-yellow-200 mb-2">When to Use Basic PID:</h4>
-              <ul className="text-sm text-focus-700 dark:text-focus-300 space-y-1 list-disc list-inside">
+              <h4 className="font-semibold text-[var(--foreground)] mb-2">When to Use Basic PID:</h4>
+              <ul className="text-sm text-[var(--foreground)] space-y-1 list-disc list-inside">
                 <li>Simple positioning tasks</li>
                 <li>Continuous control (like maintaining angle)</li>
                 <li>When speed of response is critical</li>
@@ -232,8 +232,8 @@ public void setTargetPosition(double positionRotations) {
               </ul>
             </div>
             <div>
-              <h4 className="font-semibold text-yellow-800 dark:text-yellow-200 mb-2">When to Use Motion Magic:</h4>
-              <ul className="text-sm text-focus-700 dark:text-focus-300 space-y-1 list-disc list-inside">
+              <h4 className="font-semibold text-[var(--foreground)] mb-2">When to Use Motion Magic:</h4>
+              <ul className="text-sm text-[var(--foreground)] space-y-1 list-disc list-inside">
                 <li>Large, heavy mechanisms (arms, elevators)</li>
                 <li>When smooth motion is important</li>
                 <li>Preventing mechanical stress</li>
@@ -244,13 +244,13 @@ public void setTargetPosition(double positionRotations) {
         </div>
 
         {/* Motion Magic Tuning Steps */}
-        <div className="bg-primary-50 dark:bg-primary-950/30 border border-blue-200 dark:border-blue-900 rounded-lg p-6">
-          <h3 className="text-xl font-bold text-primary-700 dark:text-primary-300 mb-4">⚙️ Motion Magic Tuning Steps</h3>
+        <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-blue-500">
+          <h3 className="text-xl font-bold text-[var(--foreground)] mb-4">⚙️ Motion Magic Tuning Steps</h3>
           
           <div className="grid md:grid-cols-2 gap-6">
             <div>
-              <h4 className="font-semibold text-primary-800 dark:text-primary-200 mb-2">1. Find Maximum Velocity:</h4>
-              <ul className="text-sm text-primary-700 dark:text-primary-300 space-y-2 list-disc list-inside">
+              <h4 className="font-semibold text-[var(--foreground)] mb-2">1. Find Maximum Velocity:</h4>
+              <ul className="text-sm text-[var(--foreground)] space-y-2 list-disc list-inside">
                 <li>Plot velocity <strong>without Motion Magic</strong></li>
                 <li>Move mechanism the maximum distance it will travel</li>
                 <li>Record the maximum velocity it reaches</li>
@@ -259,8 +259,8 @@ public void setTargetPosition(double positionRotations) {
               </ul>
             </div>
             <div>
-              <h4 className="font-semibold text-primary-800 dark:text-primary-200 mb-2">2. Set Motion Magic Parameters:</h4>
-              <ul className="text-sm text-primary-700 dark:text-primary-300 space-y-2 list-disc list-inside">
+              <h4 className="font-semibold text-[var(--foreground)] mb-2">2. Set Motion Magic Parameters:</h4>
+              <ul className="text-sm text-[var(--foreground)] space-y-2 list-disc list-inside">
                 <li><strong>Cruise Velocity:</strong> Use 80% of max velocity</li>
                 <li><code className="bg-slate-50 dark:bg-slate-800 px-1 rounded">cruiseVel = MAX_VELOCITY * 0.8</code></li>
                 <li><strong>Acceleration:</strong> Use 4x cruise velocity for smooth motion</li>
@@ -270,11 +270,11 @@ public void setTargetPosition(double positionRotations) {
             </div>
           </div>
 
-          <div className="bg-indigo-50 dark:bg-indigo-950/30 p-4 rounded mt-4">
-            <h4 className="font-semibold text-indigo-800 dark:text-indigo-200 mb-2">💡 Why This Method Works:</h4>
-            <p className="text-primary-700 dark:text-primary-300 text-sm">
-              By measuring actual mechanism performance first, you set realistic motion limits that prevent 
-              oscillation and ensure smooth, achievable motion profiles. The 80% cruise velocity provides 
+          <div className="bg-[var(--muted)] p-4 rounded mt-4 border-l-4 border-purple-500">
+            <h4 className="font-semibold text-[var(--foreground)] mb-2">💡 Why This Method Works:</h4>
+            <p className="text-[var(--foreground)] text-sm">
+              By measuring actual mechanism performance first, you set realistic motion limits that prevent
+              oscillation and ensure smooth, achievable motion profiles. The 80% cruise velocity provides
               headroom for control corrections while maintaining good performance.
             </p>
           </div>

--- a/src/app/pid-control/page.tsx
+++ b/src/app/pid-control/page.tsx
@@ -18,8 +18,8 @@ export default function PIDControl() {
           PID (Proportional-Integral-Derivative) control replaces imprecise voltage commands with accurate, 
           feedback-driven position control. Essential for mechanisms that need to hit specific targets.
         </p>
-        <div className="bg-red-100 dark:bg-red-900/30 p-4 rounded-lg">
-          <p className="text-red-800 dark:text-red-300 font-medium">
+        <div className="bg-[var(--muted)] p-4 rounded-lg border-l-4 border-red-500">
+          <p className="text-[var(--foreground)] font-medium">
             🎯 Key Concept: PID uses sensor feedback to automatically adjust motor output to reach and maintain target positions
           </p>
         </div>
@@ -32,78 +32,78 @@ export default function PIDControl() {
         </h2>
 
         <div className="grid md:grid-cols-3 gap-6">
-          <div className="bg-red-50 dark:bg-red-950/30 rounded-lg p-6 border border-red-200 dark:border-red-900">
-            <h3 className="text-xl font-bold text-focus-700 dark:text-focus-300 mb-4">🔴 P - Proportional</h3>
-            <p className="text-red-800 dark:text-red-300 mb-4 text-sm">
+          <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-red-500">
+            <h3 className="text-xl font-bold text-[var(--foreground)] mb-4">🔴 P - Proportional</h3>
+            <p className="text-[var(--foreground)] mb-4 text-sm">
               <strong>Definition:</strong> &quot;The amount of output to apply per unit of error in the system&quot;
             </p>
               <div className="bg-[var(--muted)] text-[var(--muted-foreground)] p-4 rounded mb-3">
               <code className="text-xs">Error = Target - Current</code><br/>
               <code className="text-xs">P_Output = kP × Error</code>
             </div>
-            <p className="text-focus-700 dark:text-focus-300 text-sm">
+            <p className="text-[var(--foreground)] text-sm">
               <strong>Behavior:</strong> Larger error = stronger correction. Provides immediate response but may cause oscillation.
             </p>
           </div>
 
-          <div className="bg-focus-50 dark:bg-focus-950/30 rounded-lg p-6 border border-focus-200 dark:border-focus-900">
-            <h3 className="text-xl font-bold text-focus-700 dark:text-focus-300 mb-4">🟡 I - Integral</h3>
-            <p className="text-focus-800 dark:text-focus-300 mb-4 text-sm">
+          <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-yellow-500">
+            <h3 className="text-xl font-bold text-[var(--foreground)] mb-4">🟡 I - Integral</h3>
+            <p className="text-[var(--foreground)] mb-4 text-sm">
               <strong>Definition:</strong> &quot;The amount of output to apply per unit of error for every second of that error&quot;
             </p>
               <div className="bg-[var(--muted)] text-[var(--muted-foreground)] p-4 rounded mb-3">
               <code className="text-xs">Accumulated_Error += Error × dt</code><br/>
               <code className="text-xs">I_Output = kI × Accumulated_Error</code>
             </div>
-            <p className="text-focus-700 dark:text-focus-300 text-sm">
+            <p className="text-[var(--foreground)] text-sm">
               <strong>Behavior:</strong> Eliminates steady-state error by accumulating past errors over time.
             </p>
           </div>
 
-          <div className="bg-primary-50 dark:bg-primary-950/30 rounded-lg p-6 border border-blue-200 dark:border-blue-900">
-            <h3 className="text-xl font-bold text-primary-700 dark:text-primary-300 mb-4">🔵 D - Derivative</h3>
-            <p className="text-primary-800 dark:text-primary-300 mb-4 text-sm">
+          <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-blue-500">
+            <h3 className="text-xl font-bold text-[var(--foreground)] mb-4">🔵 D - Derivative</h3>
+            <p className="text-[var(--foreground)] mb-4 text-sm">
               <strong>Definition:</strong> &quot;The amount of output to apply per change in error over time&quot;
             </p>
               <div className="bg-[var(--muted)] text-[var(--muted-foreground)] p-4 rounded mb-3">
               <code className="text-xs">Error_Rate = (Error - Last_Error) / dt</code><br/>
               <code className="text-xs">D_Output = kD × Error_Rate</code>
             </div>
-            <p className="text-primary-700 dark:text-primary-300 text-sm">
+            <p className="text-[var(--foreground)] text-sm">
               <strong>Behavior:</strong> Reduces overshoot by predicting future error trends and dampening response.
             </p>
           </div>
         </div>
 
         {/* Feedforward Components */}
-        <div className="bg-concept-50 dark:bg-concept-950/30 border border-concept-200 dark:border-concept-900 rounded-lg p-6">
-          <h3 className="text-xl font-bold text-concept-700 dark:text-concept-300 mb-4">⚡ Feedforward Gains</h3>
-          <p className="text-concept-800 dark:text-concept-300 mb-4">
+        <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-purple-500">
+          <h3 className="text-xl font-bold text-[var(--foreground)] mb-4">⚡ Feedforward Gains</h3>
+          <p className="text-[var(--foreground)] mb-4">
             Feedforward gains help the system by predicting the required output based on the target, rather than reacting to error.
           </p>
           
           <div className="grid md:grid-cols-4 gap-4">
               <div className="bg-[var(--muted)] text-[var(--muted-foreground)] p-4 rounded">
-              <h4 className="font-bold text-concept-700 dark:text-concept-300 mb-2">kS - Static</h4>
-              <p className="text-sm text-concept-600 dark:text-concept-400">
+              <h4 className="font-bold text-[var(--foreground)] mb-2">kS - Static</h4>
+              <p className="text-sm text-[var(--muted-foreground)]">
                 Constant output to overcome friction and get the mechanism moving.
               </p>
             </div>
               <div className="bg-[var(--muted)] text-[var(--muted-foreground)] p-4 rounded">
-              <h4 className="font-bold text-concept-700 dark:text-concept-300 mb-2">kG - Gravity</h4>
-              <p className="text-sm text-concept-600 dark:text-concept-400">
+              <h4 className="font-bold text-[var(--foreground)] mb-2">kG - Gravity</h4>
+              <p className="text-sm text-[var(--muted-foreground)]">
                 Compensates for gravitational forces acting on the mechanism.
               </p>
             </div>
               <div className="bg-[var(--muted)] text-[var(--muted-foreground)] p-4 rounded">
-              <h4 className="font-bold text-concept-700 dark:text-concept-300 mb-2">kV - Velocity</h4>
-              <p className="text-sm text-concept-600 dark:text-concept-400">
+              <h4 className="font-bold text-[var(--foreground)] mb-2">kV - Velocity</h4>
+              <p className="text-sm text-[var(--muted-foreground)]">
                 Output applied per target velocity to maintain smooth motion.
               </p>
             </div>
               <div className="bg-[var(--muted)] text-[var(--muted-foreground)] p-4 rounded">
-              <h4 className="font-bold text-concept-700 dark:text-concept-300 mb-2">kA - Acceleration</h4>
-              <p className="text-sm text-concept-600 dark:text-concept-400">
+              <h4 className="font-bold text-[var(--foreground)] mb-2">kA - Acceleration</h4>
+              <p className="text-sm text-[var(--muted-foreground)]">
                 Output applied per target acceleration for responsive movement.
               </p>
             </div>
@@ -111,9 +111,9 @@ export default function PIDControl() {
         </div>
 
         {/* Documentation Link */}
-        <div className="bg-indigo-50 dark:bg-indigo-950/30 border border-indigo-200 dark:border-indigo-900 rounded-lg p-6">
-          <h3 className="text-xl font-bold text-primary-700 dark:text-primary-300 mb-4">📚 Complete PID Tuning Guide</h3>
-          <p className="text-indigo-800 dark:text-indigo-300 mb-4">
+        <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-purple-500">
+          <h3 className="text-xl font-bold text-[var(--foreground)] mb-4">📚 Complete PID Tuning Guide</h3>
+          <p className="text-[var(--foreground)] mb-4">
             For detailed PID tuning instructions, step-by-step processes, and mechanism-specific guidance:
           </p>
           <a 
@@ -179,9 +179,9 @@ public void setTargetPosition(double positionRotations) {
           </h3>
           
           <div className="grid md:grid-cols-2 gap-6">
-            <div className="bg-red-50 dark:bg-red-950/30 p-4 rounded-lg border border-red-200 dark:border-red-900">
-              <h4 className="font-bold text-focus-700 dark:text-focus-300 mb-2">📋 Before</h4>
-              <ul className="text-sm text-red-800 dark:text-red-300 space-y-1">
+            <div className="bg-[var(--muted)] p-4 rounded-lg border-l-4 border-red-500">
+              <h4 className="font-bold text-[var(--foreground)] mb-2">📋 Before</h4>
+              <ul className="text-sm text-[var(--foreground)] space-y-1">
                 <li>• Commands control Arm with voltage</li>
                 <li>• No position feedback control</li>
                 <li>• Imprecise, inconsistent movement</li>

--- a/src/app/programming/page.tsx
+++ b/src/app/programming/page.tsx
@@ -35,7 +35,7 @@ export default function Programming() {
         <div className="bg-gradient-to-r from-primary-50 to-concept-50 dark:from-primary-950/30 dark:to-concept-950/30 rounded-lg p-8 border border-slate-200 dark:border-slate-800">
           <div className="grid md:grid-cols-2 gap-8">
             <div>
-              <h3 className="text-xl font-bold text-primary-700 dark:text-primary-300 mb-4">🔄 Iterative Development</h3>
+              <h3 className="text-xl font-bold text-[var(--foreground)] mb-4">🔄 Iterative Development</h3>
               <p className="text-slate-600 dark:text-slate-300 mb-4">
                 We&apos;ll start with basic motor control and progressively add advanced features.
                 Each step builds upon the previous implementation.
@@ -50,7 +50,7 @@ export default function Programming() {
             </div>
 
             <div>
-              <h3 className="text-xl font-bold text-concept-700 dark:text-concept-300 mb-4">🎯 Real-World Focus</h3>
+              <h3 className="text-xl font-bold text-[var(--foreground)] mb-4">🎯 Real-World Focus</h3>
               <p className="text-slate-600 dark:text-slate-300 mb-4">
                 Each modification addresses real competition challenges and follows
                 FRC best practices used by successful teams.
@@ -70,9 +70,9 @@ export default function Programming() {
       <section className="flex flex-col gap-8">
         <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100">Initial Arm Subsystem</h2>
 
-        <div className="bg-primary-50 dark:bg-primary-950/30 border border-primary-200 dark:border-primary-900 rounded-lg p-6">
-          <h3 className="font-semibold text-primary-700 dark:text-primary-300 mb-2">📋 Starting Point</h3>
-          <p className="text-primary-800 dark:text-primary-300">
+        <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-blue-500">
+          <h3 className="font-semibold text-[var(--foreground)] mb-2">📋 Starting Point</h3>
+          <p className="text-[var(--foreground)]">
             This is our initial Arm implementation. Throughout the workshop, we&apos;ll enhance this code by adding:
             PID control, feedforward, position control, safety limits, and more sophisticated commands.
           </p>
@@ -116,11 +116,11 @@ export default function Programming() {
           </div>
         </div>
 
-        <div className="bg-primary-50 dark:bg-primary-950/30 border border-primary-200 dark:border-primary-900 rounded-lg p-6">
-          <h3 className="text-xl font-bold text-primary-700 dark:text-primary-300 mb-4">
+        <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-blue-500">
+          <h3 className="text-xl font-bold text-[var(--foreground)] mb-4">
             🎯 Step 1: Basic Subsystem
           </h3>
-          <p className="text-primary-800 dark:text-primary-300 mb-4">
+          <p className="text-[var(--foreground)] mb-4">
             Our first step creates a foundational Arm subsystem with basic motor control and sensor feedback.
           </p>
           
@@ -181,9 +181,9 @@ export default function Programming() {
             </div>
           </div>
 
-          <div className="bg-purple-50 dark:bg-purple-950/30 p-3 rounded">
-            <p className="text-purple-800 dark:text-purple-300 text-sm">
-              <strong>Key Learning:</strong> Commands separate &quot;what to do&quot; from &quot;how to do it.&quot; 
+          <div className="bg-[var(--muted)] p-3 rounded border-l-4 border-purple-500">
+            <p className="text-[var(--foreground)] text-sm">
+              <strong>Key Learning:</strong> Commands separate &quot;what to do&quot; from &quot;how to do it.&quot;
               This makes code modular, testable, and easy to modify for different control schemes.
             </p>
           </div>
@@ -195,31 +195,31 @@ export default function Programming() {
           Step 3: Precise Control with PID
         </h2>
 
-        <div className="bg-purple-50 dark:bg-purple-950/30 border border-purple-200 dark:border-purple-900 rounded-lg p-6">
-          <h3 className="text-xl font-bold text-concept-700 dark:text-concept-300 mb-4">
+        <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-purple-500">
+          <h3 className="text-xl font-bold text-[var(--foreground)] mb-4">
             🎯 Step 3: PID Control
           </h3>
-          <p className="text-purple-800 dark:text-purple-300 mb-4">
+          <p className="text-[var(--foreground)] mb-4">
             Replace voltage control with precise PID position control for accurate, repeatable movements.
           </p>
           
           <div className="grid md:grid-cols-3 gap-4 mb-4">
-            <div className="bg-slate-50 dark:bg-slate-900 rounded-lg p-4">
-              <h4 className="font-semibold text-red-600 mb-2">P - Proportional</h4>
+            <div className="bg-[var(--muted)] rounded-lg p-4 border-l-4 border-red-500">
+              <h4 className="font-semibold text-[var(--foreground)] mb-2">🔴 P - Proportional</h4>
               <p className="text-sm text-slate-600 dark:text-slate-300">
                 Responds to current error. Larger error = stronger correction.
               </p>
             </div>
 
-            <div className="bg-slate-50 dark:bg-slate-900 rounded-lg p-4">
-              <h4 className="font-semibold text-yellow-600 mb-2">I - Integral</h4>
+            <div className="bg-[var(--muted)] rounded-lg p-4 border-l-4 border-yellow-500">
+              <h4 className="font-semibold text-[var(--foreground)] mb-2">🟡 I - Integral</h4>
               <p className="text-sm text-slate-600 dark:text-slate-300">
                 Eliminates steady-state error by accumulating past errors.
               </p>
             </div>
 
-            <div className="bg-slate-50 dark:bg-slate-900 rounded-lg p-4">
-              <h4 className="font-semibold text-primary-600 mb-2">D - Derivative</h4>
+            <div className="bg-[var(--muted)] rounded-lg p-4 border-l-4 border-blue-500">
+              <h4 className="font-semibold text-[var(--foreground)] mb-2">🔵 D - Derivative</h4>
               <p className="text-sm text-slate-600 dark:text-slate-300">
                 Reduces overshoot by predicting future error trends.
               </p>
@@ -238,7 +238,7 @@ export default function Programming() {
 
           <div className="bg-orange-50 dark:bg-orange-950/30 p-3 rounded">
             <p className="text-orange-800 dark:text-orange-300 text-sm">
-              <strong>Key Learning:</strong> PID control transforms imprecise voltage commands into 
+              <strong>Key Learning:</strong> PID control transforms imprecise voltage commands into
               accurate position control. This is essential for mechanisms that need to hit specific targets.
             </p>
           </div>
@@ -291,7 +291,7 @@ export default function Programming() {
           <h3 className="font-semibold text-slate-900 dark:text-slate-100 mb-4">🚀 What We&apos;ll Build Next</h3>
           <div className="grid md:grid-cols-2 gap-6">
             <div>
-              <h4 className="font-medium text-concept-700 dark:text-concept-300 mb-2">Enhanced Control</h4>
+              <h4 className="font-medium text-[var(--foreground)] mb-2">Enhanced Control</h4>
               <ul className="text-sm text-slate-600 dark:text-slate-300 space-y-1">
                 <li>• Position-based control</li>
                 <li>• PID feedback loops</li>
@@ -300,7 +300,7 @@ export default function Programming() {
               </ul>
             </div>
             <div>
-              <h4 className="font-medium text-primary-700 dark:text-primary-300 mb-2">Advanced Features</h4>
+              <h4 className="font-medium text-[var(--foreground)] mb-2">Advanced Features</h4>
               <ul className="text-sm text-slate-600 dark:text-slate-300 space-y-1">
                 <li>• Safety limits and bounds</li>
                 <li>• Encoder calibration</li>


### PR DESCRIPTION
## Summary
- replace red, yellow, blue and purple callout backgrounds with `bg-[var(--muted)]`
- switch callout text to `text-[var(--foreground)]`
- add colored borders/icons to differentiate callout types

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b8a79e9bf08332b13bf6a2f7f6cd56