### PR TITLE
refactor: replace gradients and purple accents with theme tokens

### DIFF
--- a/src/app/command-framework/page.tsx
+++ b/src/app/command-framework/page.tsx
@@ -70,10 +70,10 @@ export default function CommandFramework() {
                 </div>
               </div>
               <div className="flex items-center gap-4 p-4 bg-[var(--muted)] dark:bg-[var(--muted)]/30 rounded-lg">
-                <div className="bg-purple-600 text-white rounded-full w-8 h-8 flex items-center justify-center font-bold">4</div>
+                <div className="bg-[var(--muted)] text-[var(--foreground)] rounded-full w-8 h-8 flex items-center justify-center font-bold">4</div>
                 <div>
                   <h4 className="font-bold text-[var(--foreground)]">Motion Magic</h4>
-                  <p className="text-purple-600 dark:text-purple-400 text-sm">Smooth profiled motion with acceleration control</p>
+                  <p className="text-[var(--foreground)] text-sm">Smooth profiled motion with acceleration control</p>
                 </div>
               </div>
               <div className="flex items-center gap-4 p-4 bg-teal-50 dark:bg-teal-950/30 rounded-lg">

--- a/src/app/hardware/page.tsx
+++ b/src/app/hardware/page.tsx
@@ -359,8 +359,8 @@ export default function Hardware() {
                   <tr className="border-b border-slate-100 dark:border-slate-800">
                     <td className="py-3 px-3 align-top">
                       <div className="flex items-center whitespace-nowrap">
-                        <span className="inline-block w-4 h-4 bg-purple-500 rounded-full mr-2 flex-shrink-0"></span>
-                        <strong className="text-purple-700 dark:text-purple-400">Purple</strong>
+                        <span className="inline-block w-4 h-4 bg-[var(--muted)] rounded-full mr-2 flex-shrink-0"></span>
+                        <strong className="text-[var(--foreground)]">Purple</strong>
                       </div>
                     </td>
                     <td className="py-3 px-3 text-slate-700 dark:text-slate-300 align-top">Device has an unexpected/beta firmware version.</td>
@@ -428,17 +428,17 @@ export default function Hardware() {
           Let&apos;s Run Some Motors!
         </h2>
 
-        <div className="bg-gradient-to-r from-primary-50 to-concept-50 dark:from-primary-950/30 dark:to-concept-950/30 rounded-lg p-8 border border-slate-200 dark:border-slate-800">
-          <h3 className="text-xl font-semibold text-slate-900 dark:text-slate-100 mb-4">
+        <div className="bg-[var(--card)] text-[var(--foreground)] rounded-lg p-8 border border-[var(--border)]">
+          <h3 className="text-xl font-semibold text-[var(--foreground)] mb-4">
             Testing Motor Movement
           </h3>
 
           <div className="grid md:grid-cols-2 gap-6 mb-6">
             <div>
-              <h4 className="font-semibold text-slate-900 dark:text-slate-100 mb-3">
+              <h4 className="font-semibold text-[var(--foreground)] mb-3">
                 Quick Test Steps:
               </h4>
-              <ol className="list-decimal list-inside space-y-2 text-slate-700 dark:text-slate-300">
+              <ol className="list-decimal list-inside space-y-2 text-[var(--foreground)]">
                 <li>Open up your motor in Phoenix Tuner</li>
                 <li>
                   Click <strong>Config</strong>
@@ -457,7 +457,7 @@ export default function Hardware() {
               </ol>
             </div>
 
-            <div className="bg-slate-50 dark:bg-slate-900 p-4 rounded-lg border border-slate-200 dark:border-slate-800">
+            <div className="bg-slate-50 dark:bg-slate-900 p-4 rounded-lg border border-[var(--border)]">
               <h4 className="font-semibold text-slate-900 dark:text-slate-100 mb-2">
                 ⚡ Safety First
               </h4>

--- a/src/app/introduction/page.tsx
+++ b/src/app/introduction/page.tsx
@@ -29,8 +29,8 @@ export default function Introduction() {
 
       <section className="flex flex-col gap-8">
         <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100">Our Goal</h2>
-        <div className="bg-gradient-to-r from-primary-50 to-concept-50 dark:from-primary-950/30 dark:to-concept-950/30 rounded-lg p-8 border border-slate-200 dark:border-slate-800">
-          <p className="text-lg text-slate-700 dark:text-slate-300">
+        <div className="bg-[var(--card)] text-[var(--foreground)] rounded-lg p-8 border border-[var(--border)]">
+          <p className="text-lg text-[var(--foreground)]">
             Cover code architecture, subsystems structure, PID tuning, libraries, odometry, vision, and more!
           </p>
         </div>

--- a/src/app/motion-magic/page.tsx
+++ b/src/app/motion-magic/page.tsx
@@ -10,15 +10,15 @@ export default function MotionMagic() {
       nextPage={{ href: "/programming", title: "Programming" }}
     >
       {/* Introduction */}
-      <div className="bg-gradient-to-r from-primary-50 to-concept-50 dark:from-primary-950/30 dark:to-concept-950/30 rounded-lg p-8 border border-slate-200 dark:border-slate-800">
-        <h2 className="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-4">
+      <div className="bg-[var(--card)] text-[var(--foreground)] rounded-lg p-8 border border-[var(--border)]">
+        <h2 className="text-2xl font-bold text-[var(--foreground)] mb-4">
           Motion Magic - Profiled Motion Control
         </h2>
-        <p className="text-slate-600 dark:text-slate-300 mb-4">
-          Motion Magic builds on PID control by adding smooth acceleration and deceleration profiles. 
+        <p className="text-[var(--foreground)] mb-4">
+          Motion Magic builds on PID control by adding smooth acceleration and deceleration profiles.
           This prevents jerky movements and reduces mechanical stress while maintaining precise positioning.
         </p>
-        <div className="bg-[var(--muted)] p-4 rounded-lg border-l-4 border-purple-500">
+        <div className="bg-[var(--muted)] p-4 rounded-lg border-l-4 border-[var(--border)]">
           <p className="text-[var(--foreground)] font-medium">
             🚀 Key Concept: Motion Magic automatically generates smooth velocity profiles to reach target positions with controlled acceleration
           </p>
@@ -32,7 +32,7 @@ export default function MotionMagic() {
         </h2>
 
         <div className="grid md:grid-cols-2 gap-6">
-          <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-purple-500">
+          <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-[var(--border)]">
             <h3 className="text-xl font-bold text-[var(--foreground)] mb-4">📈 Trapezoidal Profile</h3>
             <p className="text-[var(--foreground)] mb-4 text-sm">
               Motion Magic creates a trapezoidal velocity profile with three phases:
@@ -79,7 +79,7 @@ export default function MotionMagic() {
         </div>
 
         {/* Documentation Link */}
-        <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-purple-500">
+        <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-[var(--border)]">
           <h3 className="text-xl font-bold text-[var(--foreground)] mb-4">📚 Official Motion Magic Documentation</h3>
           <p className="text-[var(--foreground)] mb-4">
             For complete Motion Magic reference, configuration examples, and advanced tuning techniques:
@@ -270,7 +270,7 @@ public void setTargetPosition(double positionRotations) {
             </div>
           </div>
 
-          <div className="bg-[var(--muted)] p-4 rounded mt-4 border-l-4 border-purple-500">
+          <div className="bg-[var(--muted)] p-4 rounded mt-4 border-l-4 border-[var(--border)]">
             <h4 className="font-semibold text-[var(--foreground)] mb-2">💡 Why This Method Works:</h4>
             <p className="text-[var(--foreground)] text-sm">
               By measuring actual mechanism performance first, you set realistic motion limits that prevent

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -102,8 +102,8 @@ export default function Home() {
       </div>
 
       {/* Team Introduction */}
-      <div className="bg-gradient-to-r from-primary-50 to-concept-50 dark:from-primary-950/30 dark:to-concept-950/30 p-8 rounded-lg">
-        <h2 className="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-6 text-center">
+      <div className="bg-[var(--card)] text-[var(--foreground)] p-8 rounded-lg">
+        <h2 className="text-2xl font-bold text-[var(--foreground)] mb-6 text-center">
           Meet the Team
         </h2>
         <div className="flex justify-center space-x-8 flex-wrap gap-4">

--- a/src/app/pid-control/page.tsx
+++ b/src/app/pid-control/page.tsx
@@ -74,7 +74,7 @@ export default function PIDControl() {
         </div>
 
         {/* Feedforward Components */}
-        <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-purple-500">
+        <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-[var(--border)]">
           <h3 className="text-xl font-bold text-[var(--foreground)] mb-4">⚡ Feedforward Gains</h3>
           <p className="text-[var(--foreground)] mb-4">
             Feedforward gains help the system by predicting the required output based on the target, rather than reacting to error.
@@ -109,7 +109,7 @@ export default function PIDControl() {
         </div>
 
         {/* Documentation Link */}
-        <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-purple-500">
+        <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-[var(--border)]">
           <h3 className="text-xl font-bold text-[var(--foreground)] mb-4">📚 Complete PID Tuning Guide</h3>
           <p className="text-[var(--foreground)] mb-4">
             For detailed PID tuning instructions, step-by-step processes, and mechanism-specific guidance:

--- a/src/app/programming/page.tsx
+++ b/src/app/programming/page.tsx
@@ -181,7 +181,7 @@ export default function Programming() {
             </div>
           </div>
 
-          <div className="bg-[var(--muted)] p-3 rounded border-l-4 border-purple-500">
+          <div className="bg-[var(--muted)] p-3 rounded border-l-4 border-[var(--border)]">
             <p className="text-[var(--foreground)] text-sm">
               <strong>Key Learning:</strong> Commands separate &quot;what to do&quot; from &quot;how to do it.&quot;
               This makes code modular, testable, and easy to modify for different control schemes.
@@ -195,7 +195,7 @@ export default function Programming() {
           Step 3: Precise Control with PID
         </h2>
 
-        <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-purple-500">
+        <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-[var(--border)]">
           <h3 className="text-xl font-bold text-[var(--foreground)] mb-4">
             🎯 Step 3: PID Control
           </h3>

--- a/src/components/GitHubPR.tsx
+++ b/src/components/GitHubPR.tsx
@@ -253,7 +253,7 @@ export default function GitHubPR({
                 <span
                   className={`px-2 py-1 rounded-full text-xs font-medium ${
                     pr.state === "merged"
-                      ? "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300"
+                      ? "bg-[var(--muted)] text-[var(--foreground)]"
                       : pr.state === "closed"
                       ? "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300"
                       : "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300"
@@ -366,7 +366,7 @@ export default function GitHubPR({
       </div>
 
       {/* Workshop Context */}
-        <div className="bg-gradient-to-r from-primary-50 to-concept-50 dark:from-primary-950/30 dark:to-concept-950/30 rounded-lg p-6">
+        <div className="bg-[var(--card)] text-[var(--foreground)] rounded-lg p-6">
         <h5 className="font-semibold text-[var(--foreground)] mb-3">
           🎓 Workshop Learning
         </h5>


### PR DESCRIPTION
## Summary
- replace gradient backgrounds with solid card surfaces using theme tokens
- convert purple accents to neutral theme colors and tokens
- standardize borders and text with `--foreground`, `--muted`, and `--border` tokens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b8a9ab5d9c8332ab5c3ae93b418a4b