### PR TITLE
Remove redundant nextPage prop from programming page

### DIFF
--- a/src/app/programming/page.tsx
+++ b/src/app/programming/page.tsx
@@ -7,7 +7,6 @@ export default function Programming() {
     <PageTemplate
       title="Programming Arm"
       previousPage={{ href: "/motion-magic", title: "Motion Magic" }}
-      nextPage={undefined}
     >
       <div className="bg-slate-50 dark:bg-slate-900 rounded-lg p-8 shadow-lg border border-slate-200 dark:border-slate-800">
         <h2 className="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-4">Programming Arm</h2>


### PR DESCRIPTION
## Summary
- remove unused `nextPage={undefined}` prop from programming page template

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b8accc800c8332b3eda254a3e47b53