### PR TITLE
chore: unify example header color

### DIFF
--- a/src/app/adding-commands/page.tsx
+++ b/src/app/adding-commands/page.tsx
@@ -31,7 +31,7 @@ export default function AddingCommands() {
 
           {/* Inline Command Examples */}
           <div className="card p-6">
-          <h3 className="text-xl font-bold text-concept-600 mb-4">🎮 Inline Command Methods</h3>
+          <h3 className="text-xl font-bold text-primary-600 mb-4">🎮 Inline Command Methods</h3>
           <CodeBlock
             language="java"
             title="Subsystem Command Methods"
@@ -163,7 +163,7 @@ public class RobotContainer {
 
           {/* RobotContainer Implementation */}
           <div className="card p-6">
-          <h3 className="text-xl font-bold text-practice-600 mb-4">🤖 RobotContainer Implementation</h3>
+          <h3 className="text-xl font-bold text-primary-600 mb-4">🤖 RobotContainer Implementation</h3>
           <CodeBlock
             language="java"
             title="Complete RobotContainer.java"

--- a/src/app/building-subsystems/page.tsx
+++ b/src/app/building-subsystems/page.tsx
@@ -31,7 +31,7 @@ export default function BuildingSubsystems() {
 
         {/* Subsystem Example */}
         <div className="bg-slate-50 dark:bg-slate-900 rounded-lg p-6 shadow-lg border border-slate-200 dark:border-slate-800">
-          <h3 className="text-xl font-bold text-learn-600 mb-4">📦 Basic Subsystem Structure</h3>
+          <h3 className="text-xl font-bold text-primary-600 mb-4">📦 Basic Subsystem Structure</h3>
           <CodeBlock
             language="java"
             title="ExampleSubsystem.java"

--- a/src/app/motion-magic/page.tsx
+++ b/src/app/motion-magic/page.tsx
@@ -105,7 +105,7 @@ export default function MotionMagic() {
         </h2>
 
         <div className="bg-slate-50 dark:bg-slate-900 rounded-lg p-6 shadow-lg border border-slate-200 dark:border-slate-800">
-          <h3 className="text-xl font-bold text-learn-600 mb-4">🔧 Motion Magic Configuration Example</h3>
+          <h3 className="text-xl font-bold text-primary-600 mb-4">🔧 Motion Magic Configuration Example</h3>
           <CodeBlock
             language="java"
             title="Motion Magic Setup in Subsystem Constructor"

--- a/src/app/pid-control/page.tsx
+++ b/src/app/pid-control/page.tsx
@@ -135,7 +135,7 @@ export default function PIDControl() {
         </h2>
 
           <div className="card p-6">
-          <h3 className="text-xl font-bold text-learn-600 mb-4">🔧 PID Configuration Example</h3>
+          <h3 className="text-xl font-bold text-primary-600 mb-4">🔧 PID Configuration Example</h3>
           <CodeBlock
             language="java"
             title="PID Setup in Subsystem Constructor"


### PR DESCRIPTION
## Summary
- standardize example code headings across pages to `text-primary-600`
- align inline command and RobotContainer examples with shared color class
- update subsystem, PID, and Motion Magic examples for consistency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b8adb1b5e08332b8aee98845ca9163