### PR TITLE
style: standardize walkthrough styling

### DIFF
--- a/src/app/building-subsystems/page.tsx
+++ b/src/app/building-subsystems/page.tsx
@@ -164,22 +164,22 @@ public class ExampleSubsystem extends SubsystemBase {
           focusFile="Arm.java" 
         />
 
-        <div className="bg-primary-50 dark:bg-primary-950/30 border border-primary-200 dark:border-primary-900 rounded-lg p-6">
-          <h3 className="text-xl font-bold text-learn-700 dark:text-learn-300 mb-4">🔍 Code Walkthrough</h3>
+        <div className="bg-learn-100 dark:bg-learn-900/20 border border-learn-200 dark:border-learn-900 rounded-lg p-6">
+          <h3 className="text-xl font-bold text-learn-900 dark:text-learn-300 mb-4">🔍 Code Walkthrough</h3>
           
           <div className="grid md:grid-cols-2 gap-6">
             <div>
-              <h4 className="font-semibold text-primary-800 dark:text-primary-200 mb-2">Hardware Setup:</h4>
-              <ul className="text-sm text-primary-700 dark:text-primary-300 space-y-1">
+              <h4 className="font-semibold text-learn-800 dark:text-learn-200 mb-2">Hardware Setup:</h4>
+              <ul className="text-sm text-learn-700 dark:text-learn-300 space-y-1">
                 <li>• <strong>TalonFX Motor:</strong> Main drive motor with integrated controller</li>
                 <li>• <strong>CANCoder:</strong> Absolute position feedback sensor</li>
                 <li>• <strong>Remote Sensor:</strong> CANCoder connected as remote feedback</li>
               </ul>
             </div>
-            
+
             <div>
-              <h4 className="font-semibold text-primary-800 dark:text-primary-200 mb-2">Key Methods:</h4>
-              <ul className="text-sm text-primary-700 dark:text-primary-300 space-y-1">
+              <h4 className="font-semibold text-learn-800 dark:text-learn-200 mb-2">Key Methods:</h4>
+              <ul className="text-sm text-learn-700 dark:text-learn-300 space-y-1">
                 <li>• <strong>setVoltage():</strong> Direct voltage control for basic movement</li>
                 <li>• <strong>stop():</strong> Safe motor stop with neutral output</li>
                 <li>• <strong>periodic():</strong> Understand that periodic runs every robot loop</li>

--- a/src/app/motion-magic/page.tsx
+++ b/src/app/motion-magic/page.tsx
@@ -185,23 +185,23 @@ public void setTargetPosition(double positionRotations) {
           focusFile="Arm.java" 
         />
 
-        <div className="bg-orange-50 dark:bg-orange-950/30 border border-orange-200 dark:border-orange-900 rounded-lg p-6">
-          <h3 className="text-xl font-bold text-learn-700 dark:text-learn-300 mb-4">🔍 Code Walkthrough</h3>
+        <div className="bg-learn-100 dark:bg-learn-900/20 border border-learn-200 dark:border-learn-900 rounded-lg p-6">
+          <h3 className="text-xl font-bold text-learn-900 dark:text-learn-300 mb-4">🔍 Code Walkthrough</h3>
           
           <div className="grid md:grid-cols-2 gap-6">
             <div>
-              <h4 className="font-semibold text-orange-800 dark:text-orange-200 mb-2">Motion Magic Parameters:</h4>
-              <ul className="text-sm text-orange-700 dark:text-orange-300 space-y-1">
+              <h4 className="font-semibold text-learn-800 dark:text-learn-200 mb-2">Motion Magic Parameters:</h4>
+              <ul className="text-sm text-learn-700 dark:text-learn-300 space-y-1">
                 <li>• <strong>Cruise Velocity (2.0):</strong> Maximum speed during motion</li>
                 <li>• <strong>Acceleration (8.0):</strong> How quickly to reach cruise speed</li>
                 <li>• <strong>Jerk (80.0):</strong> Smoothness of acceleration changes</li>
                 <li>• <strong>MotionMagicVoltage:</strong> Replaces PositionVoltage for profiled control</li>
               </ul>
             </div>
-            
+
             <div>
-              <h4 className="font-semibold text-orange-800 dark:text-orange-200 mb-2">Enhanced Features:</h4>
-              <ul className="text-sm text-orange-700 dark:text-orange-300 space-y-1">
+              <h4 className="font-semibold text-learn-800 dark:text-learn-200 mb-2">Enhanced Features:</h4>
+              <ul className="text-sm text-learn-700 dark:text-learn-300 space-y-1">
                 <li>• <strong>Setpoint Detection:</strong> Checks both position AND velocity</li>
                 <li>• <strong>Smooth Motion:</strong> Eliminates jerky arm movements</li>
                 <li>• <strong>Mechanical Safety:</strong> Reduces stress on gearboxes</li>

--- a/src/app/pid-control/page.tsx
+++ b/src/app/pid-control/page.tsx
@@ -209,22 +209,22 @@ public void setTargetPosition(double positionRotations) {
           focusFile="Arm.java" 
         />
 
-        <div className="bg-orange-50 dark:bg-orange-950/30 border border-orange-200 dark:border-orange-900 rounded-lg p-6">
-          <h3 className="text-xl font-bold text-learn-700 dark:text-learn-300 mb-4">🔍 Code Walkthrough</h3>
+        <div className="bg-learn-100 dark:bg-learn-900/20 border border-learn-200 dark:border-learn-900 rounded-lg p-6">
+          <h3 className="text-xl font-bold text-learn-900 dark:text-learn-300 mb-4">🔍 Code Walkthrough</h3>
           
           <div className="grid md:grid-cols-2 gap-6">
             <div>
-              <h4 className="font-semibold text-orange-800 dark:text-orange-200 mb-2">PID Implementation:</h4>
-              <ul className="text-sm text-orange-700 dark:text-orange-300 space-y-1">
+              <h4 className="font-semibold text-learn-800 dark:text-learn-200 mb-2">PID Implementation:</h4>
+              <ul className="text-sm text-learn-700 dark:text-learn-300 space-y-1">
                 <li>• <strong>PositionVoltage:</strong> Replaces VoltageOut for closed-loop control</li>
                 <li>• <strong>Slot0 Config:</strong> PID and feedforward gains configuration</li>
                 <li>• <strong>Target Setting:</strong> setTargetPosition() method for precise control</li>
               </ul>
             </div>
-            
+
             <div>
-              <h4 className="font-semibold text-orange-800 dark:text-orange-200 mb-2">Gain Values Used:</h4>
-              <ul className="text-sm text-orange-700 dark:text-orange-300 space-y-1">
+              <h4 className="font-semibold text-learn-800 dark:text-learn-200 mb-2">Gain Values Used:</h4>
+              <ul className="text-sm text-learn-700 dark:text-learn-300 space-y-1">
                 <li>• <strong>kP = 24.0:</strong> Strong proportional response</li>
                 <li>• <strong>kD = 0.1:</strong> Small derivative for damping</li>
                 <li>• <strong>kS = 0.25:</strong> Static friction compensation</li>


### PR DESCRIPTION
## Summary
- align Code Walkthrough blocks with standard learn-themed container styling
- update headings to use learn color scheme
- adjust inner text colors for readability

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b8adf9a07883329291f3206bad287a