### PR TITLE
Refactor Before/After blocks with shared styles

### DIFF
--- a/src/app/adding-commands/page.tsx
+++ b/src/app/adding-commands/page.tsx
@@ -130,9 +130,9 @@ public class RobotContainer {
           </h3>
           
           <div className="grid md:grid-cols-2 gap-6">
-            <div className="bg-red-50 dark:bg-red-950/30 p-4 rounded-lg border border-red-200 dark:border-red-900">
-              <h4 className="font-bold text-red-700 dark:text-red-300 mb-2">📋 Before</h4>
-              <ul className="text-sm text-red-800 dark:text-red-300 space-y-1">
+            <div className="before-block">
+              <h4 className="before-title">📋 Before</h4>
+              <ul className="text-sm space-y-1">
                 <li>• Arm subsystem with basic voltage control</li>
                 <li>• No user input integration</li>
                 <li>• No commands to coordinate actions</li>
@@ -140,9 +140,9 @@ public class RobotContainer {
               </ul>
             </div>
 
-            <div className="bg-learn-100 dark:bg-learn-900/20 p-4 rounded-lg border border-learn-200 dark:border-learn-900">
-              <h4 className="font-bold text-learn-700 dark:text-learn-300 mb-2">✅ After</h4>
-              <ul className="text-sm text-learn-800 dark:text-learn-300 space-y-1">
+            <div className="after-block">
+              <h4 className="after-title">✅ After</h4>
+              <ul className="text-sm space-y-1">
                 <li>• Enhanced Arm subsystem methods</li>
                 <li>• Xbox controller integration</li>
                 <li>• Commands for moveUp(), moveDown()</li>

--- a/src/app/building-subsystems/page.tsx
+++ b/src/app/building-subsystems/page.tsx
@@ -135,18 +135,18 @@ public class ExampleSubsystem extends SubsystemBase {
           </h3>
           
           <div className="grid md:grid-cols-2 gap-6">
-            <div className="bg-red-50 dark:bg-red-950/30 p-4 rounded-lg border border-red-200 dark:border-red-900">
-              <h4 className="font-bold text-red-700 dark:text-red-300 mb-2">📋 Before (Empty Project)</h4>
-              <ul className="text-sm text-red-800 dark:text-red-300 space-y-1">
+            <div className="before-block">
+              <h4 className="before-title">📋 Before (Empty Project)</h4>
+              <ul className="text-sm space-y-1">
                 <li>• Basic WPILib project structure</li>
                 <li>• No hardware integration</li>
                 <li>• No subsystem implementation</li>
               </ul>
             </div>
 
-            <div className="bg-green-50 dark:bg-green-950/30 p-4 rounded-lg border border-green-200 dark:border-green-900">
-              <h4 className="font-bold text-green-700 dark:text-green-300 mb-2">✅ After</h4>
-              <ul className="text-sm text-green-800 dark:text-green-300 space-y-1">
+            <div className="after-block">
+              <h4 className="after-title">✅ After</h4>
+              <ul className="text-sm space-y-1">
                 <li>• Complete Arm subsystem class</li>
                 <li>• TalonFX motor (ID: 31) configured</li>
                 <li>• CANCoder sensor (ID: 22) integrated</li>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -110,3 +110,18 @@
 }
 
 @custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
+
+@layer components {
+  .before-block {
+    @apply bg-red-50 dark:bg-red-950/30 p-4 rounded-lg border border-red-200 dark:border-red-900 text-red-800 dark:text-red-300;
+  }
+  .before-title {
+    @apply font-bold text-red-700 dark:text-red-300 mb-2;
+  }
+  .after-block {
+    @apply bg-learn-50 dark:bg-learn-900/20 p-4 rounded-lg border border-learn-200 dark:border-learn-900 text-learn-800 dark:text-learn-300;
+  }
+  .after-title {
+    @apply font-bold text-learn-700 dark:text-learn-300 mb-2;
+  }
+}

--- a/src/app/motion-magic/page.tsx
+++ b/src/app/motion-magic/page.tsx
@@ -153,9 +153,9 @@ public void setTargetPosition(double positionRotations) {
           </h3>
           
           <div className="grid md:grid-cols-2 gap-6">
-            <div className="bg-[var(--muted)] p-4 rounded-lg border-l-4 border-red-500">
-              <h4 className="font-bold text-[var(--foreground)] mb-2">📋 Before</h4>
-              <ul className="text-sm text-[var(--foreground)] space-y-1">
+            <div className="before-block">
+              <h4 className="before-title">📋 Before</h4>
+              <ul className="text-sm space-y-1">
                 <li>• PID position control with PositionVoltage</li>
                 <li>• Instant acceleration to target</li>
                 <li>• Potential mechanical stress from jerky movements</li>
@@ -164,9 +164,9 @@ public void setTargetPosition(double positionRotations) {
               </ul>
             </div>
 
-            <div className="bg-learn-50 dark:bg-learn-950/30 p-4 rounded-lg border border-green-200 dark:border-green-900">
-              <h4 className="font-bold text-learn-700 dark:text-learn-300 mb-2">✅ After</h4>
-              <ul className="text-sm text-learn-800 dark:text-learn-300 space-y-1">
+            <div className="after-block">
+              <h4 className="after-title">✅ After</h4>
+              <ul className="text-sm space-y-1">
                 <li>• Motion Magic profiled motion with MotionMagicVoltage</li>
                 <li>• Smooth acceleration and deceleration curves</li>
                 <li>• Reduced mechanical stress and wear</li>

--- a/src/app/pid-control/page.tsx
+++ b/src/app/pid-control/page.tsx
@@ -177,9 +177,9 @@ public void setTargetPosition(double positionRotations) {
           </h3>
           
           <div className="grid md:grid-cols-2 gap-6">
-            <div className="bg-[var(--muted)] p-4 rounded-lg border-l-4 border-red-500">
-              <h4 className="font-bold text-[var(--foreground)] mb-2">📋 Before</h4>
-              <ul className="text-sm text-[var(--foreground)] space-y-1">
+            <div className="before-block">
+              <h4 className="before-title">📋 Before</h4>
+              <ul className="text-sm space-y-1">
                 <li>• Commands control Arm with voltage</li>
                 <li>• No position feedback control</li>
                 <li>• Imprecise, inconsistent movement</li>
@@ -188,9 +188,9 @@ public void setTargetPosition(double positionRotations) {
               </ul>
             </div>
 
-            <div className="bg-learn-50 dark:bg-learn-950/30 p-4 rounded-lg border border-green-200 dark:border-green-900">
-              <h4 className="font-bold text-learn-700 dark:text-learn-300 mb-2">✅ After</h4>
-              <ul className="text-sm text-learn-800 dark:text-learn-300 space-y-1">
+            <div className="after-block">
+              <h4 className="after-title">✅ After</h4>
+              <ul className="text-sm space-y-1">
                 <li>• PID position control with PositionVoltage</li>
                 <li>• Automatic target position reaching</li>
                 <li>• Precise, repeatable movements</li>


### PR DESCRIPTION
## Summary
- add reusable before-block/after-block utilities for consistent styling
- refactor Before/After sections to use shared classes across workshop pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b8ad9d2a0c83328b7e904e5ecac956