### PR TITLE
Standardize Next Step section styling

### DIFF
--- a/src/app/mechanism-setup/page.tsx
+++ b/src/app/mechanism-setup/page.tsx
@@ -125,18 +125,18 @@ export default function MechanismSetup() {
           </div>
         </div>
 
-        {/* Next Steps */}
+          {/* Next Step */}
         <div className="bg-[var(--muted)] border border-[var(--border)] rounded-lg p-6">
           <h3 className="text-xl font-bold text-[var(--foreground)] mb-4">✅ Ready for Control</h3>
           <p className="text-[var(--muted-foreground)] mb-4">
             Once your mechanism moves in the correct direction and encoders provide accurate feedback, you&apos;re ready to implement advanced control algorithms.
           </p>
-          <div className="bg-[var(--muted)] p-4 rounded">
-            <p className="text-[var(--muted-foreground)] text-sm">
-              <strong>🚀 Next Step:</strong> With verified hardware setup, we can now implement PID control for precise positioning.
-              The control algorithm will use the encoder feedback to automatically reach target positions.
-            </p>
-          </div>
+            <div className="bg-indigo-50 dark:bg-indigo-950/30 p-4 rounded mt-4">
+              <p className="text-indigo-800 dark:text-indigo-300 text-sm">
+                <strong>💡 Next Step:</strong> With verified hardware setup, we can now implement PID control for precise positioning.
+                The control algorithm will use the encoder feedback to automatically reach target positions.
+              </p>
+            </div>
         </div>
       </section>
     </PageTemplate>

--- a/src/app/motion-magic/page.tsx
+++ b/src/app/motion-magic/page.tsx
@@ -210,12 +210,12 @@ public void setTargetPosition(double positionRotations) {
             </div>
           </div>
 
-          <div className="bg-teal-50 dark:bg-teal-950/30 p-4 rounded mt-4">
-            <p className="text-teal-800 dark:text-teal-300 text-sm">
-              <strong>💡 Next Step:</strong> Motion Magic gives us professional-grade motion control! 
-              Next, we&apos;ll explore tuning methods to get optimal performance from our control algorithms.
-            </p>
-          </div>
+            <div className="bg-indigo-50 dark:bg-indigo-950/30 p-4 rounded mt-4">
+              <p className="text-indigo-800 dark:text-indigo-300 text-sm">
+                <strong>💡 Next Step:</strong> Motion Magic gives us professional-grade motion control!
+                Next, we&apos;ll explore tuning methods to get optimal performance from our control algorithms.
+              </p>
+            </div>
         </div>
 
         {/* Motion Magic vs PID Comparison */}

--- a/src/app/pid-control/page.tsx
+++ b/src/app/pid-control/page.tsx
@@ -233,12 +233,12 @@ public void setTargetPosition(double positionRotations) {
             </div>
           </div>
 
-          <div className="bg-teal-50 dark:bg-teal-950/30 p-4 rounded mt-4">
-            <p className="text-teal-800 dark:text-teal-300 text-sm">
-              <strong>💡 Next Step:</strong> PID gives us precise control! 
-              In the next section, we&apos;ll upgrade to Motion Magic for smooth, profiled movements with controlled acceleration.
-            </p>
-          </div>
+            <div className="bg-indigo-50 dark:bg-indigo-950/30 p-4 rounded mt-4">
+              <p className="text-indigo-800 dark:text-indigo-300 text-sm">
+                <strong>💡 Next Step:</strong> PID gives us precise control!
+                In the next section, we&apos;ll upgrade to Motion Magic for smooth, profiled movements with controlled acceleration.
+              </p>
+            </div>
         </div>
 
       </section>

--- a/src/app/project-setup/page.tsx
+++ b/src/app/project-setup/page.tsx
@@ -132,9 +132,9 @@ export default function ProjectSetup() {
         className="w-full h-full aspect-video rounded-lg"
       />
 
-      <div className="bg-practice-100 dark:bg-practice-900/20 border border-practice-200 dark:border-practice-800 rounded-lg p-6">
-        <p className="text-practice-800 dark:text-practice-200">
-          ✅ <strong>Next Steps:</strong> After creating your project, you&apos;ll learn about the Command Framework in the next section. Your project will be ready for implementing subsystems and commands!
+      <div className="bg-indigo-50 dark:bg-indigo-950/30 p-4 rounded mt-4">
+        <p className="text-indigo-800 dark:text-indigo-300 text-sm">
+          <strong>💡 Next Step:</strong> After creating your project, you&apos;ll learn about the Command Framework in the next section. Your project will be ready for implementing subsystems and commands!
         </p>
       </div>
     </PageTemplate>


### PR DESCRIPTION
## Summary
- unify "Next Step" callouts across mechanism, motion-magic, pid-control, and project-setup pages
- switch each section to indigo theme and consistent 💡 icon

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b8b01a96a4833282e3e968c894d270