### PR TITLE
Standardize Key Concept sections

### DIFF
--- a/src/app/building-subsystems/page.tsx
+++ b/src/app/building-subsystems/page.tsx
@@ -16,8 +16,8 @@ export default function BuildingSubsystems() {
           Subsystems are the foundation of command-based programming. They represent physical hardware components and provide
           methods to control them safely and effectively.
         </p>
-        <div className="bg-primary-100 dark:bg-primary-900/30 p-4 rounded-lg">
-          <p className="text-primary-800 dark:text-primary-300 font-medium">
+        <div className="bg-learn-100 dark:bg-learn-900/30 p-4 rounded-lg">
+          <p className="text-learn-800 dark:text-learn-300 font-medium">
             🎯 Key Concept: One subsystem per mechanism - each subsystem manages its own hardware and state
           </p>
         </div>

--- a/src/app/mechanism-setup/page.tsx
+++ b/src/app/mechanism-setup/page.tsx
@@ -15,9 +15,9 @@ export default function MechanismSetup() {
             Before implementing advanced control algorithms, we need to verify that motors and encoders are working correctly.
             This ensures proper direction, zeroing, and basic functionality.
           </p>
-        <div className="bg-focus-100 dark:bg-focus-900/30 p-4 rounded-lg">
-          <p className="text-focus-800 dark:text-focus-300 font-medium">
-            🔍 Key Concept: Always verify hardware setup before adding control algorithms - this prevents debugging control issues when the problem is hardware configuration
+        <div className="bg-learn-100 dark:bg-learn-900/30 p-4 rounded-lg">
+          <p className="text-learn-800 dark:text-learn-300 font-medium">
+            🎯 Key Concept: Always verify hardware setup before adding control algorithms - this prevents debugging control issues when the problem is hardware configuration
           </p>
         </div>
       </div>

--- a/src/app/motion-magic/page.tsx
+++ b/src/app/motion-magic/page.tsx
@@ -18,9 +18,9 @@ export default function MotionMagic() {
           Motion Magic builds on PID control by adding smooth acceleration and deceleration profiles.
           This prevents jerky movements and reduces mechanical stress while maintaining precise positioning.
         </p>
-        <div className="bg-[var(--muted)] p-4 rounded-lg border-l-4 border-[var(--border)]">
-          <p className="text-[var(--foreground)] font-medium">
-            🚀 Key Concept: Motion Magic automatically generates smooth velocity profiles to reach target positions with controlled acceleration
+        <div className="bg-learn-100 dark:bg-learn-900/30 p-4 rounded-lg">
+          <p className="text-learn-800 dark:text-learn-300 font-medium">
+            🎯 Key Concept: Motion Magic automatically generates smooth velocity profiles to reach target positions with controlled acceleration
           </p>
         </div>
       </div>

--- a/src/app/pid-control/page.tsx
+++ b/src/app/pid-control/page.tsx
@@ -16,8 +16,8 @@ export default function PIDControl() {
           PID (Proportional-Integral-Derivative) control replaces imprecise voltage commands with accurate, 
           feedback-driven position control. Essential for mechanisms that need to hit specific targets.
         </p>
-        <div className="bg-[var(--muted)] p-4 rounded-lg border-l-4 border-red-500">
-          <p className="text-[var(--foreground)] font-medium">
+        <div className="bg-learn-100 dark:bg-learn-900/30 p-4 rounded-lg">
+          <p className="text-learn-800 dark:text-learn-300 font-medium">
             🎯 Key Concept: PID uses sensor feedback to automatically adjust motor output to reach and maintain target positions
           </p>
         </div>


### PR DESCRIPTION
## Summary
- use consistent "Key Concept" styling across workshop pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b8b05558d08332b6ce1e9b6ef2a748