### PR TITLE
Add workshop flow links to introduction page

### DIFF
--- a/src/app/introduction/page.tsx
+++ b/src/app/introduction/page.tsx
@@ -94,6 +94,56 @@ export default function Introduction() {
               </Link>
 
               <Link
+                href="/building-subsystems"
+                className="block p-3 bg-slate-100 dark:bg-slate-800 rounded-lg hover:bg-primary-100 dark:hover:bg-primary-950/30 transition-colors group"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="font-medium text-slate-700 dark:text-slate-300 group-hover:text-primary-700 dark:group-hover:text-primary-300">Building Subsystems</span>
+                  <span className="text-slate-400 dark:text-slate-500 group-hover:text-primary-500 dark:group-hover:text-primary-300">→</span>
+                </div>
+              </Link>
+
+              <Link
+                href="/adding-commands"
+                className="block p-3 bg-slate-100 dark:bg-slate-800 rounded-lg hover:bg-primary-100 dark:hover:bg-primary-950/30 transition-colors group"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="font-medium text-slate-700 dark:text-slate-300 group-hover:text-primary-700 dark:group-hover:text-primary-300">Adding Commands</span>
+                  <span className="text-slate-400 dark:text-slate-500 group-hover:text-primary-500 dark:group-hover:text-primary-300">→</span>
+                </div>
+              </Link>
+
+              <Link
+                href="/mechanism-setup"
+                className="block p-3 bg-slate-100 dark:bg-slate-800 rounded-lg hover:bg-primary-100 dark:hover:bg-primary-950/30 transition-colors group"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="font-medium text-slate-700 dark:text-slate-300 group-hover:text-primary-700 dark:group-hover:text-primary-300">Mechanism Setup</span>
+                  <span className="text-slate-400 dark:text-slate-500 group-hover:text-primary-500 dark:group-hover:text-primary-300">→</span>
+                </div>
+              </Link>
+
+              <Link
+                href="/pid-control"
+                className="block p-3 bg-slate-100 dark:bg-slate-800 rounded-lg hover:bg-primary-100 dark:hover:bg-primary-950/30 transition-colors group"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="font-medium text-slate-700 dark:text-slate-300 group-hover:text-primary-700 dark:group-hover:text-primary-300">PID Control</span>
+                  <span className="text-slate-400 dark:text-slate-500 group-hover:text-primary-500 dark:group-hover:text-primary-300">→</span>
+                </div>
+              </Link>
+
+              <Link
+                href="/motion-magic"
+                className="block p-3 bg-slate-100 dark:bg-slate-800 rounded-lg hover:bg-primary-100 dark:hover:bg-primary-950/30 transition-colors group"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="font-medium text-slate-700 dark:text-slate-300 group-hover:text-primary-700 dark:group-hover:text-primary-300">Motion Magic</span>
+                  <span className="text-slate-400 dark:text-slate-500 group-hover:text-primary-500 dark:group-hover:text-primary-300">→</span>
+                </div>
+              </Link>
+
+              <Link
                 href="/programming"
                 className="block p-3 bg-slate-100 dark:bg-slate-800 rounded-lg hover:bg-primary-100 dark:hover:bg-primary-950/30 transition-colors group"
               >


### PR DESCRIPTION
## Summary
- Add navigation links for Building Subsystems, Adding Commands, Mechanism Setup, PID Control, and Motion Magic on the Workshop #1 section of the introduction page.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b8b28713a88332b0dfe7de7564a27d