### PR TITLE
Standardize Workshop #1 page heading styles

### DIFF
--- a/src/app/adding-commands/page.tsx
+++ b/src/app/adding-commands/page.tsx
@@ -11,7 +11,7 @@ export default function AddingCommands() {
     >
       {/* Introduction */}
       <div className="bg-[var(--card)] text-[var(--foreground)] rounded-lg p-8 border border-[var(--border)]">
-        <h2 className="text-2xl font-bold mb-4">Command-Based Programming</h2>
+        <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100 mb-4">Command-Based Programming</h2>
         <p className="text-[var(--muted-foreground)] mb-4">
           Commands are the &quot;actions&quot; that your robot performs. They use subsystems to accomplish tasks and can be triggered
           by user input, sensors, or automated sequences.
@@ -25,7 +25,7 @@ export default function AddingCommands() {
 
       {/* Command Examples */}
       <section className="flex flex-col gap-8">
-        <h2 className="text-3xl font-bold text-[var(--foreground)]">
+        <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100">
           Command Structure & Examples
         </h2>
 
@@ -120,7 +120,7 @@ public class RobotContainer {
 
       {/* Before/After Implementation */}
       <section className="flex flex-col gap-8">
-        <h2 className="text-3xl font-bold text-[var(--foreground)]">
+        <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100">
           Workshop Implementation: Adding Commands to Arm
         </h2>
 

--- a/src/app/building-subsystems/page.tsx
+++ b/src/app/building-subsystems/page.tsx
@@ -11,7 +11,7 @@ export default function BuildingSubsystems() {
     >
       {/* Introduction */}
       <div className="bg-[var(--card)] text-[var(--foreground)] rounded-lg p-8 border border-[var(--border)]">
-        <h2 className="text-2xl font-bold mb-4">Understanding Subsystems</h2>
+        <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100 mb-4">Understanding Subsystems</h2>
         <p className="mb-4">
           Subsystems are the foundation of command-based programming. They represent physical hardware components and provide
           methods to control them safely and effectively.

--- a/src/app/mechanism-setup/page.tsx
+++ b/src/app/mechanism-setup/page.tsx
@@ -10,7 +10,7 @@ export default function MechanismSetup() {
     >
       {/* Introduction */}
         <div className="bg-[var(--card)] text-[var(--foreground)] rounded-lg p-8 border border-[var(--border)]">
-          <h2 className="text-2xl font-bold mb-4">Verifying Your Mechanism Setup</h2>
+          <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100 mb-4">Verifying Your Mechanism Setup</h2>
           <p className="text-[var(--muted-foreground)] mb-4">
             Before implementing advanced control algorithms, we need to verify that motors and encoders are working correctly.
             This ensures proper direction, zeroing, and basic functionality.
@@ -24,7 +24,7 @@ export default function MechanismSetup() {
 
       {/* Encoder Verification */}
       <section className="flex flex-col gap-8">
-          <h2 className="text-3xl font-bold text-[var(--foreground)]">
+          <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100">
           Encoder Direction and Zeroing
         </h2>
 

--- a/src/app/motion-magic/page.tsx
+++ b/src/app/motion-magic/page.tsx
@@ -11,7 +11,7 @@ export default function MotionMagic() {
     >
       {/* Introduction */}
       <div className="bg-[var(--card)] text-[var(--foreground)] rounded-lg p-8 border border-[var(--border)]">
-        <h2 className="text-2xl font-bold text-[var(--foreground)] mb-4">
+        <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100 mb-4">
           Motion Magic - Profiled Motion Control
         </h2>
         <p className="text-[var(--foreground)] mb-4">

--- a/src/app/pid-control/page.tsx
+++ b/src/app/pid-control/page.tsx
@@ -11,7 +11,7 @@ export default function PIDControl() {
     >
       {/* Introduction */}
         <div className="bg-[var(--card)] text-[var(--foreground)] rounded-lg p-8 border border-[var(--border)]">
-          <h2 className="text-2xl font-bold mb-4">PID Control - Precise Position Control</h2>
+          <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100 mb-4">PID Control - Precise Position Control</h2>
           <p className="text-[var(--muted-foreground)] mb-4">
           PID (Proportional-Integral-Derivative) control replaces imprecise voltage commands with accurate, 
           feedback-driven position control. Essential for mechanisms that need to hit specific targets.
@@ -25,7 +25,7 @@ export default function PIDControl() {
 
       {/* PID Theory */}
       <section className="flex flex-col gap-8">
-        <h2 className="text-3xl font-bold text-[var(--foreground)]">
+        <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100">
           Understanding PID Components
         </h2>
 
@@ -130,7 +130,7 @@ export default function PIDControl() {
 
       {/* Code Implementation */}
       <section className="flex flex-col gap-8">
-          <h2 className="text-3xl font-bold text-[var(--foreground)]">
+          <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100">
           PID Implementation in Code
         </h2>
 

--- a/src/app/prerequisites/page.tsx
+++ b/src/app/prerequisites/page.tsx
@@ -6,7 +6,7 @@ export default function Prerequisites() {
       <div className="grid gap-6">
         {/* Software Requirements */}
         <div className="bg-slate-50 dark:bg-slate-900 rounded-lg p-6 shadow-lg border border-slate-200 dark:border-slate-800">
-          <h2 className="text-2xl font-bold text-primary-600 mb-4">📋 Software Requirements</h2>
+          <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100 mb-4">📋 Software Requirements</h2>
 
           <div className="space-y-6">
             <div className="border-l-4 border-primary-200 dark:border-primary-900 pl-4">

--- a/src/app/programming/page.tsx
+++ b/src/app/programming/page.tsx
@@ -9,7 +9,7 @@ export default function Programming() {
       previousPage={{ href: "/motion-magic", title: "Motion Magic" }}
     >
       <div className="bg-slate-50 dark:bg-slate-900 rounded-lg p-8 shadow-lg border border-slate-200 dark:border-slate-800">
-        <h2 className="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-4">Programming Arm</h2>
+        <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100 mb-4">Programming Arm</h2>
         <p className="text-slate-600 dark:text-slate-300 mb-6">
           In this section, we&apos;ll program common FRC mechanisms starting with our Arm subsystem.
           We&apos;ll build upon this initial implementation throughout the workshop.

--- a/src/app/project-setup/page.tsx
+++ b/src/app/project-setup/page.tsx
@@ -8,7 +8,7 @@ export default function ProjectSetup() {
       nextPage={{ href: "/command-framework", title: "Command Framework" }}
     >
       <div className="bg-slate-50 dark:bg-slate-900 rounded-lg p-8 shadow-lg border border-slate-200 dark:border-slate-800">
-        <h2 className="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-6">Creating a New WPILib Project</h2>
+        <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100 mb-6">Creating a New WPILib Project</h2>
         <p className="text-slate-600 dark:text-slate-300 mb-6">Follow these step-by-step instructions to create a new FRC robot project using the Command Robot Skeleton (Advanced) template.</p>
 
         <div className="space-y-4">


### PR DESCRIPTION
## Summary
- unify `h2` headings across Workshop #1 pages with consistent styling
- remove ad-hoc heading size overrides

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b8b29557c4833281e94b6210563c2b