### PR TITLE
refactor: use ImageBlock for standalone illustrations

### DIFF
--- a/src/app/mechanism-setup/page.tsx
+++ b/src/app/mechanism-setup/page.tsx
@@ -1,5 +1,5 @@
 import PageTemplate from "@/components/PageTemplate";
-import Image from "next/image";
+import ImageBlock from "@/components/ImageBlock";
 
 export default function MechanismSetup() {
   return (
@@ -51,7 +51,13 @@ export default function MechanismSetup() {
             </div>
 
             <div className="flex w-full justify-center">
-              <Image src="/images/mechanisms/arm.jpg" alt="Arm mechanism for encoder verification" width={300} height={200} className="rounded-lg" />
+              <ImageBlock
+                src="/images/mechanisms/arm.jpg"
+                alt="Arm mechanism for encoder verification"
+                width={300}
+                height={200}
+                className="rounded-lg"
+              />
             </div>
           </div>
 

--- a/src/app/programming/page.tsx
+++ b/src/app/programming/page.tsx
@@ -1,6 +1,6 @@
 import PageTemplate from "@/components/PageTemplate";
 import GithubPageWithPR from "@/components/GithubPageWithPR";
-import Image from "next/image";
+import ImageBlock from "@/components/ImageBlock";
 
 export default function Programming() {
   return (
@@ -280,7 +280,13 @@ export default function Programming() {
           <p className="col-span-2">You&apos;ll want to make sure your motor is spinning in the expected direction. If the motor is getting positive voltage, it should be spinning counterclockwise. You can check this through tuner, with the device facing your like the following picture.</p>
 
           <div className="flex w-full">
-            <Image src="/images/mechanisms/arm.jpg" alt="Arm" width={300} height={200} className="rounded-lg" />
+            <ImageBlock
+              src="/images/mechanisms/arm.jpg"
+              alt="Arm"
+              width={300}
+              height={200}
+              className="rounded-lg"
+            />
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- replace next/image with ImageBlock in mechanism-setup and programming pages
- remove unused Image imports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b8c350a8f883329fe18c9fd9661251