### PR TITLE
refactor: standardize h2 heading styles

### DIFF
--- a/src/app/hardware/page.tsx
+++ b/src/app/hardware/page.tsx
@@ -10,7 +10,7 @@ export default function Hardware() {
     >
       {/* Introduction */}
       <div className="bg-[var(--card)] text-[var(--foreground)] rounded-lg p-8 border border-[var(--border)]">
-        <h2 className="text-2xl font-bold mb-4">Hardware Setup - Building the Foundation</h2>
+        <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100 mb-4">Hardware Setup - Building the Foundation</h2>
         <p className="text-[var(--muted-foreground)] mb-4">
           Overview of the motors, sensors, and controllers you&apos;ll connect for this workshop.
         </p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,7 +33,7 @@ export default function Home() {
       {/* Workshop Overview */}
       <div className="max-w-2xl mx-auto">
         <div className="bg-slate-50 dark:bg-slate-900 p-8 rounded-lg shadow-lg border border-slate-200 dark:border-slate-800 text-center">
-          <h2 className="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-4">
+          <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100 mb-4">
             Target Audience
           </h2>
           <p className="text-slate-600 dark:text-slate-300 mb-6">
@@ -56,7 +56,7 @@ export default function Home() {
 
       {/* Mechanisms Section */}
       <div>
-        <h2 className="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-8 text-center">
+        <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100 mb-8 text-center">
           Mechanisms We&apos;ll Program
         </h2>
         <div className="grid md:grid-cols-2 gap-8">
@@ -103,7 +103,7 @@ export default function Home() {
 
       {/* Team Introduction */}
       <div className="bg-[var(--card)] text-[var(--foreground)] p-8 rounded-lg">
-        <h2 className="text-2xl font-bold text-[var(--foreground)] mb-6 text-center">
+        <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100 mb-6 text-center">
           Meet the Team
         </h2>
         <div className="flex justify-center space-x-8 flex-wrap gap-4">

--- a/src/app/project-setup/page.tsx
+++ b/src/app/project-setup/page.tsx
@@ -9,7 +9,7 @@ export default function ProjectSetup() {
     >
       {/* Introduction */}
       <div className="bg-[var(--card)] text-[var(--foreground)] rounded-lg p-8 border border-[var(--border)]">
-        <h2 className="text-2xl font-bold mb-4">Project Setup - Launching Your Codebase</h2>
+        <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100 mb-4">Project Setup - Launching Your Codebase</h2>
         <p className="text-[var(--muted-foreground)] mb-4">
           Step-by-step guide to generating a new WPILib project using the Command framework template.
         </p>


### PR DESCRIPTION
## Summary
- unify H2 headings on hardware, project setup, and home pages
- apply consistent `text-3xl` bold styling across workshop pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b9ef9df3dc8332b36027a7c95a55bb