### PR TITLE
Add running program guide and update navigation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ Workshop Content:
     ├── /hardware (CTRE hardware setup)
     ├── /project-setup (WPILib project creation)
     ├── /command-framework (Triggers, subsystems, commands)
-    ├── /programming (Arm & Flywheel implementation)
+    ├── /running-program (Run code with hardware sim)
     ├── /control-systems (PID & Feedforward theory)
 ```
 

--- a/src/app/adding-commands/page.tsx
+++ b/src/app/adding-commands/page.tsx
@@ -7,7 +7,7 @@ export default function AddingCommands() {
     <PageTemplate
       title="Commands"
       previousPage={{ href: "/building-subsystems", title: "Subsystems" }}
-      nextPage={{ href: "/mechanism-setup", title: "Mechanism Setup" }}
+      nextPage={{ href: "/running-program", title: "Running Program" }}
     >
       {/* Introduction */}
       <div className="bg-[var(--card)] text-[var(--foreground)] rounded-lg p-8 border border-[var(--border)]">

--- a/src/app/introduction/page.tsx
+++ b/src/app/introduction/page.tsx
@@ -114,6 +114,16 @@ export default function Introduction() {
               </Link>
 
               <Link
+                href="/running-program"
+                className="block p-3 bg-slate-100 dark:bg-slate-800 rounded-lg hover:bg-primary-100 dark:hover:bg-primary-950/30 transition-colors group"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="font-medium text-slate-700 dark:text-slate-300 group-hover:text-primary-700 dark:group-hover:text-primary-300">Running Program</span>
+                  <span className="text-slate-400 dark:text-slate-500 group-hover:text-primary-500 dark:group-hover:text-primary-300">→</span>
+                </div>
+              </Link>
+
+              <Link
                 href="/mechanism-setup"
                 className="block p-3 bg-slate-100 dark:bg-slate-800 rounded-lg hover:bg-primary-100 dark:hover:bg-primary-950/30 transition-colors group"
               >
@@ -142,18 +152,6 @@ export default function Introduction() {
                   <span className="text-slate-400 dark:text-slate-500 group-hover:text-primary-500 dark:group-hover:text-primary-300">→</span>
                 </div>
               </Link>
-
-              <Link
-                href="/programming"
-                className="block p-3 bg-slate-100 dark:bg-slate-800 rounded-lg hover:bg-primary-100 dark:hover:bg-primary-950/30 transition-colors group"
-              >
-                <div className="flex items-center justify-between">
-                  <span className="font-medium text-slate-700 dark:text-slate-300 group-hover:text-primary-700 dark:group-hover:text-primary-300">Programming</span>
-                  <span className="text-slate-400 dark:text-slate-500 group-hover:text-primary-500 dark:group-hover:text-primary-300">→</span>
-                </div>
-              </Link>
-
-
             </div>
 
             <Link

--- a/src/app/mechanism-setup/page.tsx
+++ b/src/app/mechanism-setup/page.tsx
@@ -5,7 +5,7 @@ export default function MechanismSetup() {
   return (
     <PageTemplate
       title="Mechanism Setup"
-      previousPage={{ href: "/adding-commands", title: "Adding Commands" }}
+      previousPage={{ href: "/running-program", title: "Running Program" }}
       nextPage={{ href: "/pid-control", title: "PID Control" }}
     >
       {/* Introduction */}

--- a/src/app/running-program/page.tsx
+++ b/src/app/running-program/page.tsx
@@ -1,0 +1,29 @@
+import PageTemplate from "@/components/PageTemplate";
+
+export default function RunningProgram() {
+  return (
+    <PageTemplate
+      title="Running Program"
+      previousPage={{ href: "/adding-commands", title: "Commands" }}
+      nextPage={{ href: "/mechanism-setup", title: "Mechanism Setup" }}
+    >
+      <section className="flex flex-col gap-8 bg-slate-50 dark:bg-slate-900 rounded-lg p-8 shadow-lg border border-slate-200 dark:border-slate-800">
+        <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100">
+          Running with Hardware Sim
+        </h2>
+
+        <p>WPILib provides a powerful tool called Hardware Simulation. This allows you to run your code in the simulator, while also running motors that are connected to the CANivore.</p>
+        <p>This prevents the need to run a full roboRIO for testing, while still allowing you to test your code on real hardware.</p>
+
+        <iframe
+          src="https://www.youtube.com/embed/xsR7m6ToUFE"
+          title="Hardware Simulation"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+          className="w-full h-full aspect-video rounded-lg"
+        />
+      </section>
+    </PageTemplate>
+  );
+}
+

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -159,6 +159,25 @@ const workshop1Items = [
     ),
   },
   {
+    href: "/running-program",
+    label: "Running Program",
+    icon: (
+      <svg
+        className="w-5 h-5"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M14.752 11.168l-5.197-3.031A1 1 0 008 9.031v5.938a1 1 0 001.555.832l5.197-3.031a1 1 0 000-1.664z"
+        />
+      </svg>
+    ),
+  },
+  {
     href: "/mechanism-setup",
     label: "Mechanism Setup",
     icon: (


### PR DESCRIPTION
## Summary
- add dedicated Running Program page with hardware sim instructions
- link new page throughout workshop navigation
- update route overview docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b9f6b7b40883329db5aefd194a5581