### PR TITLE
feat: add key concept to running program

### DIFF
--- a/src/app/running-program/page.tsx
+++ b/src/app/running-program/page.tsx
@@ -14,6 +14,11 @@ export default function RunningProgram() {
 
         <p>WPILib provides a powerful tool called Hardware Simulation. This allows you to run your code in the simulator, while also running motors that are connected to the CANivore.</p>
         <p>This prevents the need to run a full roboRIO for testing, while still allowing you to test your code on real hardware.</p>
+        <div className="bg-learn-100 dark:bg-learn-900/30 p-4 rounded-lg">
+          <p className="text-learn-800 dark:text-learn-300 font-medium">
+            🎯 Key Concept: Hardware simulation lets you test code with real CAN devices without deploying to a roboRIO.
+          </p>
+        </div>
 
         <iframe
           src="https://www.youtube.com/embed/xsR7m6ToUFE"


### PR DESCRIPTION
## Summary
- highlight hardware simulation key concept on Running Program page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b9ff6c2d1c8332bf5a83bfe0f317ac