### PR TITLE
Restore Workshop #1 section while keeping README generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Gray Matter Coding Workshop #1 Website
+# Gray Matter Coding Workshop Website
 
 🌐 **Live Site: [ctre-workshop-site.vercel.app](https://ctre-workshop-site.vercel.app)**
 
-A responsive website built with Next.js and Tailwind CSS that converts the Gray Matter Coding Workshop #1 Canva presentation into an accessible markdown-based learning platform.
+A responsive website built with Next.js and Tailwind CSS that converts the Gray Matter Coding Workshop Canva presentation into an accessible markdown-based learning platform.
 
 ## 🎯 About
 


### PR DESCRIPTION
## Summary
- Reintroduce explicit "Workshop #1" labels on introduction page card and start button
- Restore sidebar navigation and state names for "Workshop #1" section
- Update developer guide route map to reflect "Workshop #1" collapsible section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bb3cf518ac8332a115f53447bbda88