### PR TITLE
feat: add reusable alert box

### DIFF
--- a/src/app/building-subsystems/page.tsx
+++ b/src/app/building-subsystems/page.tsx
@@ -3,6 +3,7 @@ import PageTemplate from "@/components/PageTemplate";
 import ConceptBox from "@/components/ConceptBox";
 import CodeBlock from "@/components/CodeBlock";
 import KeyConceptSection from "@/components/KeyConceptSection";
+import AlertBox from "@/components/AlertBox";
 
 export default function BuildingSubsystems() {
   return (
@@ -111,25 +112,32 @@ public class ExampleSubsystem extends SubsystemBase {
       </section>
 
       {/* Follower Motor Caution */}
-      <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-6">
-        <div className="flex items-start gap-3">
-          <svg className="w-6 h-6 text-yellow-600 dark:text-yellow-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.732-.833-2.464 0L4.35 16.5c-.77.833.192 2.5 1.732 2.5z" />
+      <AlertBox
+        variant="warning"
+        icon={
+          <svg
+            className="w-6 h-6"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.732-.833-2.464 0L4.35 16.5c-.77.833.192 2.5 1.732 2.5z"
+            />
           </svg>
-          <div>
-            <h3 className="text-lg font-bold text-yellow-800 dark:text-yellow-300 mb-2">Caution: Physical Hardware vs Code Example</h3>
-            <p className="text-yellow-700 dark:text-yellow-300 mb-3">
-              The flywheel device built in this workshop does <strong>not</strong> have a physical follower motor. However, the following code examples 
-              include a follower motor setup to demonstrate best practices for multi-motor subsystems.
-            </p>
-            <div className="bg-yellow-100 dark:bg-yellow-900/30 p-3 rounded border border-yellow-200 dark:border-yellow-700">
-              <p className="text-yellow-800 dark:text-yellow-200 text-sm">
-                <strong>Note:</strong> If implementing on actual hardware, you would either remove the follower motor code or add a second physical motor to your flywheel mechanism.
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
+        }
+        title="Caution: Physical Hardware vs Code Example"
+      >
+        <p className="mb-3">
+          The flywheel device built in this workshop does <strong>not</strong> have a physical follower motor. However, the following code examples include a follower motor setup to demonstrate best practices for multi-motor subsystems.
+        </p>
+        <AlertBox variant="warning" title="Note" className="mt-3">
+          If implementing on actual hardware, you would either remove the follower motor code or add a second physical motor to your flywheel mechanism.
+        </AlertBox>
+      </AlertBox>
 
       {/* Mechanism Implementation Tabs */}
       <MechanismTabs

--- a/src/app/hardware/page.tsx
+++ b/src/app/hardware/page.tsx
@@ -2,6 +2,7 @@ import PageTemplate from "@/components/PageTemplate";
 import ImageBlock from "@/components/ImageBlock";
 import KeyConceptSection from "@/components/KeyConceptSection";
 import ContentCard from "@/components/ContentCard";
+import AlertBox from "@/components/AlertBox";
 
 export default function Hardware() {
   return (
@@ -202,18 +203,15 @@ export default function Hardware() {
           Connecting to Your Device
         </h2>
 
-        <div className="bg-yellow-100 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-6">
-          <h3 className="text-lg font-semibold text-yellow-700 dark:text-yellow-300 mb-3">
-            ⚠️ Important Setup Steps
-          </h3>
-          <ol className="list-decimal list-inside space-y-2 text-yellow-800 dark:text-yellow-300">
+        <AlertBox variant="warning" title="⚠️ Important Setup Steps">
+          <ol className="list-decimal list-inside space-y-2">
             <li>Plug the computer into CANivore</li>
             <li>Make sure the &quot;CANivore USB&quot; is checked</li>
             <li>Change &quot;Team # or IP&quot; to &quot;localhost&quot;</li>
             <li>Your CANivore should now appear in Phoenix Tuner</li>
             <li>For this workshop, please name your CANivore: &quot;canivore&quot;</li>
           </ol>
-        </div>
+        </AlertBox>
       </section>
 
       <section className="flex flex-col gap-8">
@@ -304,11 +302,8 @@ export default function Hardware() {
           </ContentCard>
         </div>
 
-        <div className="bg-primary-100 dark:bg-primary-900/20 border border-blue-200 dark:border-blue-900 rounded-lg p-6">
-          <h4 className="text-lg font-semibold text-primary-900 dark:text-primary-300 mb-4">
-            🎨 Card Colors
-          </h4>
-          <p className="text-[var(--foreground)] mb-3">
+        <AlertBox variant="info" title="🎨 Card Colors">
+          <p className="mb-3">
             The color of the device cards is helpful as a visual indicator of device state. The meaning of the card color is also shown as text underneath the device title.
           </p>
 
@@ -372,12 +367,10 @@ export default function Hardware() {
             </div>
           </div>
 
-          <div className="mt-4 p-3 bg-blue-100 dark:bg-blue-900/50 rounded-lg">
-            <p className="text-blue-800 dark:text-blue-300 text-sm">
-              <strong>💡 Tip:</strong> Always update all motors to the same firmware version for consistency and use batch update to save time when updating multiple devices.
-            </p>
-          </div>
-        </div>
+          <AlertBox variant="tip" title="💡 Tip" className="mt-4">
+            Always update all motors to the same firmware version for consistency and use batch update to save time when updating multiple devices.
+          </AlertBox>
+        </AlertBox>
       </section>
 
       <section className="flex flex-col gap-8">

--- a/src/app/mechanism-cad/page.tsx
+++ b/src/app/mechanism-cad/page.tsx
@@ -4,6 +4,7 @@ import PageTemplate from "@/components/PageTemplate";
 import ModelViewer from "@/components/ModelViewer";
 import BillOfMaterials from "@/components/BillOfMaterials";
 import KeyConceptSection from "@/components/KeyConceptSection";
+import AlertBox from "@/components/AlertBox";
 import { armBOMData } from "@/data/armBOM";
 
 export default function MechanismCAD() {
@@ -124,10 +125,7 @@ export default function MechanismCAD() {
         </div>
 
         {/* File Format Guide */}
-        <div className="bg-blue-100 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-6">
-          <h4 className="text-lg font-semibold text-blue-900 dark:text-blue-300 mb-3">
-            📋 File Format Guide
-          </h4>
+        <AlertBox variant="info" title="📋 File Format Guide">
           <div className="grid md:grid-cols-2 gap-4 text-sm">
             <div>
               <h5 className="font-bold text-blue-800 dark:text-blue-300 mb-2">STL Files</h5>
@@ -142,7 +140,7 @@ export default function MechanismCAD() {
               </p>
             </div>
           </div>
-        </div>
+        </AlertBox>
 
         {/* Arm Bill of Materials */}
         <div className="mt-8">

--- a/src/app/pid-control/page.tsx
+++ b/src/app/pid-control/page.tsx
@@ -3,6 +3,7 @@ import PageTemplate from "@/components/PageTemplate";
 import CodeBlock from "@/components/CodeBlock";
 import KeyConceptSection from "@/components/KeyConceptSection";
 import ConceptBox from "@/components/ConceptBox";
+import AlertBox from "@/components/AlertBox";
 
 export default function PIDControl() {
   return (
@@ -69,35 +70,33 @@ export default function PIDControl() {
         </div>
 
         {/* Feedforward Components */}
-        <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-[var(--border)]">
-          <h3 className="text-xl font-bold text-[var(--foreground)] mb-4">⚡ Feedforward Gains</h3>
-          <p className="text-[var(--foreground)] mb-4">
+        <AlertBox variant="info" title="⚡ Feedforward Gains">
+          <p className="mb-4">
             Feedforward gains help the system by predicting the required output based on the target, rather than reacting to error.
           </p>
-          
-            <div className="grid md:grid-cols-4 gap-4">
-              <ConceptBox title="kS - Static">
-                Constant output to overcome friction and get the mechanism moving.
-              </ConceptBox>
-              <ConceptBox title="kG - Gravity">
-                Compensates for gravitational forces acting on the mechanism.
-              </ConceptBox>
-              <ConceptBox title="kV - Velocity">
-                Output applied per target velocity to maintain smooth motion.
-              </ConceptBox>
-              <ConceptBox title="kA - Acceleration">
-                Output applied per target acceleration for responsive movement.
-              </ConceptBox>
-            </div>
-        </div>
+
+          <div className="grid md:grid-cols-4 gap-4">
+            <ConceptBox title="kS - Static">
+              Constant output to overcome friction and get the mechanism moving.
+            </ConceptBox>
+            <ConceptBox title="kG - Gravity">
+              Compensates for gravitational forces acting on the mechanism.
+            </ConceptBox>
+            <ConceptBox title="kV - Velocity">
+              Output applied per target velocity to maintain smooth motion.
+            </ConceptBox>
+            <ConceptBox title="kA - Acceleration">
+              Output applied per target acceleration for responsive movement.
+            </ConceptBox>
+          </div>
+        </AlertBox>
 
         {/* Documentation Link */}
-        <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-[var(--border)]">
-          <h3 className="text-xl font-bold text-[var(--foreground)] mb-4">📚 Complete PID Tuning Guide</h3>
-          <p className="text-[var(--foreground)] mb-4">
+        <AlertBox variant="info" title="📚 Complete PID Tuning Guide">
+          <p className="mb-4">
             For detailed PID tuning instructions, step-by-step processes, and mechanism-specific guidance:
           </p>
-          <a 
+          <a
             href="https://phoenixpro-documentation--161.org.readthedocs.build/en/161/docs/application-notes/manual-pid-tuning.html"
             target="_blank"
             rel="noopener noreferrer"
@@ -108,7 +107,7 @@ export default function PIDControl() {
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
             </svg>
           </a>
-        </div>
+        </AlertBox>
       </section>
 
       {/* Code Implementation */}

--- a/src/app/project-setup/page.tsx
+++ b/src/app/project-setup/page.tsx
@@ -1,5 +1,6 @@
 import PageTemplate from "@/components/PageTemplate";
 import KeyConceptSection from "@/components/KeyConceptSection";
+import AlertBox from "@/components/AlertBox";
 
 export default function ProjectSetup() {
   return (
@@ -74,11 +75,9 @@ export default function ProjectSetup() {
             </span>
             <div>
               <p className="font-medium">Base folder select &quot;Downloads&quot;</p>
-              <div className="bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-900 rounded p-3 mt-2">
-                <p className="text-red-800 dark:text-red-300 text-sm">
-                  ⚠️ <strong>Warning:</strong> OneDrive locations are not supported and will cause project creation to fail.
-                </p>
-              </div>
+              <AlertBox variant="warning" title="⚠️ Warning" className="mt-2">
+                OneDrive locations are not supported and will cause project creation to fail.
+              </AlertBox>
             </div>
           </div>
 
@@ -140,11 +139,9 @@ export default function ProjectSetup() {
         className="w-full h-full aspect-video rounded-lg"
       />
 
-      <div className="bg-indigo-50 dark:bg-indigo-950/30 p-4 rounded mt-4">
-        <p className="text-indigo-800 dark:text-indigo-300 text-sm">
-          <strong>💡 Next Step:</strong> After creating your project, you&apos;ll learn about the Command-Based Framework in the next section. Your project will be ready for implementing subsystems and commands!
-        </p>
-      </div>
+      <AlertBox variant="tip" title="💡 Next Step" className="mt-4">
+        After creating your project, you&apos;ll learn about the Command-Based Framework in the next section. Your project will be ready for implementing subsystems and commands!
+      </AlertBox>
     </PageTemplate>
   );
 }

--- a/src/app/running-program/page.tsx
+++ b/src/app/running-program/page.tsx
@@ -1,5 +1,6 @@
 import PageTemplate from "@/components/PageTemplate";
 import KeyConceptSection from "@/components/KeyConceptSection";
+import AlertBox from "@/components/AlertBox";
 
 export default function RunningProgram() {
   return (
@@ -15,26 +16,33 @@ export default function RunningProgram() {
         concept="Hardware simulation eliminates the need to use a roboRIO for testing, while still allowing you to test your code on hardware."
       />
 
-      {/* CANivore USB Warning */}
-      <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-6">
-        <div className="flex items-start gap-3">
-          <svg className="w-6 h-6 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.732-.833-2.464 0L4.35 16.5c-.77.833.192 2.5 1.732 2.5z" />
-          </svg>
-          <div>
-            <h3 className="text-lg font-bold text-red-800 dark:text-red-300 mb-2">Important: CANivore USB Setting</h3>
-            <p className="text-red-700 dark:text-red-300 mb-3">
-              Before running Hardware Simulation code, you <strong>must</strong> turn <strong>OFF</strong> the &quot;CANivore USB&quot; setting in TunerX. 
-              This prevents conflicts between the simulation environment and physical hardware communication.
-            </p>
-            <div className="bg-red-100 dark:bg-red-900/30 p-3 rounded border border-red-200 dark:border-red-700">
-              <p className="text-red-800 dark:text-red-200 text-sm">
-                <strong>Steps:</strong> Open TunerX → Go to CANivore settings → Disable &quot;CANivore USB&quot;
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
+        {/* CANivore USB Warning */}
+        <AlertBox
+          variant="warning"
+          icon={
+            <svg
+              className="w-6 h-6"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.732-.833-2.464 0L4.35 16.5c-.77.833.192 2.5 1.732 2.5z"
+              />
+            </svg>
+          }
+          title="Important: CANivore USB Setting"
+        >
+          <p className="mb-3">
+            Before running Hardware Simulation code, you <strong>must</strong> turn <strong>OFF</strong> the &quot;CANivore USB&quot; setting in TunerX. This prevents conflicts between the simulation environment and physical hardware communication.
+          </p>
+          <AlertBox variant="warning" title="Steps" className="mt-3">
+            Open TunerX → Go to CANivore settings → Disable &quot;CANivore USB&quot;
+          </AlertBox>
+        </AlertBox>
 
       <section className="flex flex-col gap-8">
         <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100">

--- a/src/components/AlertBox.tsx
+++ b/src/components/AlertBox.tsx
@@ -1,0 +1,52 @@
+import { ReactNode } from "react";
+import clsx from "clsx";
+
+export type AlertVariant = "warning" | "info" | "success" | "tip";
+
+interface AlertBoxProps {
+  variant: AlertVariant;
+  title?: ReactNode;
+  icon?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}
+
+const variantStyles: Record<AlertVariant, { container: string; text: string }> = {
+  warning: {
+    container: "bg-yellow-50 dark:bg-yellow-900/20 border-yellow-200 dark:border-yellow-800",
+    text: "text-yellow-800 dark:text-yellow-300",
+  },
+  info: {
+    container: "bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800",
+    text: "text-blue-800 dark:text-blue-200",
+  },
+  success: {
+    container: "bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800",
+    text: "text-green-800 dark:text-green-200",
+  },
+  tip: {
+    container: "bg-indigo-50 dark:bg-indigo-950/30 border-indigo-200 dark:border-indigo-800",
+    text: "text-indigo-800 dark:text-indigo-300",
+  },
+};
+
+export default function AlertBox({
+  variant,
+  title,
+  icon,
+  children,
+  className,
+}: AlertBoxProps) {
+  const styles = variantStyles[variant];
+  return (
+    <div className={clsx("border rounded-lg p-4", styles.container, className)}>
+      <div className="flex items-start gap-3">
+        {icon && <div className={clsx("mt-0.5", styles.text)}>{icon}</div>}
+        <div className={clsx("space-y-1 text-sm", styles.text)}>
+          {title && <p className="font-semibold">{title}</p>}
+          <div>{children}</div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable `AlertBox` component with variant styling and optional icon/title
- replace ad-hoc alert divs with `AlertBox` across hardware, subsystems, PID, project setup, running program, and mechanism CAD pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68be9463e0108332952e0a535fc2e6ed