### PR TITLE
feat: add reusable step list component

### DIFF
--- a/src/app/hardware/page.tsx
+++ b/src/app/hardware/page.tsx
@@ -2,6 +2,7 @@ import PageTemplate from "@/components/PageTemplate";
 import ImageBlock from "@/components/ImageBlock";
 import KeyConceptSection from "@/components/KeyConceptSection";
 import ContentCard from "@/components/ContentCard";
+import StepList from "@/components/StepList";
 
 export default function Hardware() {
   return (
@@ -206,13 +207,17 @@ export default function Hardware() {
           <h3 className="text-lg font-semibold text-yellow-700 dark:text-yellow-300 mb-3">
             ⚠️ Important Setup Steps
           </h3>
-          <ol className="list-decimal list-inside space-y-2 text-yellow-800 dark:text-yellow-300">
-            <li>Plug the computer into CANivore</li>
-            <li>Make sure the &quot;CANivore USB&quot; is checked</li>
-            <li>Change &quot;Team # or IP&quot; to &quot;localhost&quot;</li>
-            <li>Your CANivore should now appear in Phoenix Tuner</li>
-            <li>For this workshop, please name your CANivore: &quot;canivore&quot;</li>
-          </ol>
+          <StepList
+            variant="numbered"
+            className="text-yellow-800 dark:text-yellow-300"
+            steps={[
+              "Plug the computer into CANivore",
+              "Make sure the \"CANivore USB\" is checked",
+              "Change \"Team # or IP\" to \"localhost\"",
+              "Your CANivore should now appear in Phoenix Tuner",
+              "For this workshop, please name your CANivore: \"canivore\"",
+            ]}
+          />
         </div>
       </section>
 
@@ -226,56 +231,47 @@ export default function Hardware() {
             Using Phoenix Tuner
           </h3>
 
-          <div className="space-y-4">
-            <div className="flex items-start space-x-3">
-              <span className="bg-green-500 text-white rounded-full w-6 h-6 flex items-center justify-center text-sm font-bold">
-                ✓
-              </span>
-              <div>
-                <p className="font-medium">
-                  Open Phoenix Tuner and connect to your robot
-                </p>
-                <p className="text-slate-600 dark:text-slate-300 text-sm">
-                  If you have issues connecting to your robot,
-                  <a
-                    href="https://v6.docs.ctr-electronics.com/en/stable/docs/tuner/connecting.html#connecting-tuner"
-                    className="text-primary-600 underline hover:no-underline dark:text-primary-400 ml-1"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    view this guide
-                  </a>
-                </p>
-              </div>
-            </div>
-
-            <div className="flex items-start space-x-3">
-              <span className="bg-green-500 text-white rounded-full w-6 h-6 flex items-center justify-center text-sm font-bold">
-                ✓
-              </span>
-              <div>
-                <p className="font-medium">
-                  Batch update all products of the same model
-                </p>
-                <p className="text-slate-600 dark:text-slate-300 text-sm">
-                  Select one of the devices and then click the batch update
-                  icons
-                </p>
-              </div>
-            </div>
-
-            <div className="flex items-start space-x-3">
-              <span className="bg-green-500 text-white rounded-full w-6 h-6 flex items-center justify-center text-sm font-bold">
-                ✓
-              </span>
-              <div>
-                <p className="font-medium">Verify Updates</p>
-                <p className="text-slate-600 dark:text-slate-300 text-sm">
-                  The device cards will be green if the firmware is the latest
-                </p>
-              </div>
-            </div>
-          </div>
+          <StepList
+            variant="checkmark"
+            steps={[
+              (
+                <div key="connect">
+                  <p className="font-medium">
+                    Open Phoenix Tuner and connect to your robot
+                  </p>
+                  <p className="text-slate-600 dark:text-slate-300 text-sm">
+                    If you have issues connecting to your robot,
+                    <a
+                      href="https://v6.docs.ctr-electronics.com/en/stable/docs/tuner/connecting.html#connecting-tuner"
+                      className="text-primary-600 underline hover:no-underline dark:text-primary-400 ml-1"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      view this guide
+                    </a>
+                  </p>
+                </div>
+              ),
+              (
+                <div key="batch">
+                  <p className="font-medium">
+                    Batch update all products of the same model
+                  </p>
+                  <p className="text-slate-600 dark:text-slate-300 text-sm">
+                    Select one of the devices and then click the batch update icons
+                  </p>
+                </div>
+              ),
+              (
+                <div key="verify">
+                  <p className="font-medium">Verify Updates</p>
+                  <p className="text-slate-600 dark:text-slate-300 text-sm">
+                    The device cards will be green if the firmware is the latest
+                  </p>
+                </div>
+              ),
+            ]}
+          />
         </ContentCard>
       </section>
 
@@ -413,23 +409,35 @@ export default function Hardware() {
               <h4 className="font-semibold text-[var(--foreground)] mb-3">
                 Quick Test Steps:
               </h4>
-              <ol className="list-decimal list-inside space-y-2 text-[var(--foreground)]">
-                <li>Open up your motor in Phoenix Tuner</li>
-                <li>
-                  Click <strong>Config</strong>
-                </li>
-                <li>Click the three dots</li>
-                <li>
-                  Click <strong>Factory Default</strong>
-                </li>
-                <li>
-                  Set the drop-down to <strong>Voltage Out</strong>
-                </li>
-                <li>
-                  Click <strong>DISABLED</strong> to enable
-                </li>
-                <li>Apply voltage to test the motor</li>
-              </ol>
+              <StepList
+                variant="numbered"
+                className="text-[var(--foreground)]"
+                steps={[
+                  "Open up your motor in Phoenix Tuner",
+                  (
+                    <span key="config">
+                      Click <strong>Config</strong>
+                    </span>
+                  ),
+                  "Click the three dots",
+                  (
+                    <span key="factory">
+                      Click <strong>Factory Default</strong>
+                    </span>
+                  ),
+                  (
+                    <span key="voltage">
+                      Set the drop-down to <strong>Voltage Out</strong>
+                    </span>
+                  ),
+                  (
+                    <span key="enable">
+                      Click <strong>DISABLED</strong> to enable
+                    </span>
+                  ),
+                  "Apply voltage to test the motor",
+                ]}
+              />
             </div>
 
             <div className="bg-slate-50 dark:bg-slate-900 p-4 rounded-lg border border-[var(--border)]">

--- a/src/app/mechanism-setup/page.tsx
+++ b/src/app/mechanism-setup/page.tsx
@@ -5,6 +5,7 @@ import PageTemplate from "@/components/PageTemplate";
 import ImageBlock from "@/components/ImageBlock";
 import KeyConceptSection from "@/components/KeyConceptSection";
 import ConceptBox from "@/components/ConceptBox";
+import StepList from "@/components/StepList";
 
 export default function MechanismSetup() {
   const [activeTab, setActiveTab] = useState<"arm" | "flywheel">("arm");
@@ -139,31 +140,51 @@ export default function MechanismSetup() {
                   <div className="bg-slate-50 dark:bg-slate-900 rounded-lg p-6 shadow-lg border border-slate-200 dark:border-slate-800">
                     <h4 className="text-xl font-bold text-[var(--foreground)] mb-4">🔧 Implementation Sequence</h4>
                     
-                    <div className="space-y-4">
-                      <div className="flex items-center gap-4 p-4 bg-primary-50 dark:bg-primary-950/20 rounded-lg">
-                        <div className="bg-primary-500 text-white rounded-full w-8 h-8 flex items-center justify-center font-bold">1</div>
-                        <div>
-                          <h4 className="font-bold text-primary-700 dark:text-primary-300">Rotate Counter-Clockwise</h4>
-                          <p className="text-primary-600 dark:text-primary-400 text-sm">Manually rotate the mechanism counter-clockwise and observe if the encoder position increases.</p>
-                        </div>
-                      </div>
-                      
-                      <div className="flex items-center gap-4 p-4 bg-primary-100 dark:bg-primary-900/30 rounded-lg">
-                        <div className="bg-primary-600 text-white rounded-full w-8 h-8 flex items-center justify-center font-bold">2</div>
-                        <div>
-                          <h4 className="font-bold text-primary-800 dark:text-primary-200">Fix Direction if Needed</h4>
-                          <p className="text-primary-700 dark:text-primary-300 text-sm">If position goes down instead of up, go to &quot;Info&quot; → &quot;Sensor Direction&quot; → press &quot;Apply&quot; button to invert the encoder direction.</p>
-                        </div>
-                      </div>
-                      
-                      <div className="flex items-center gap-4 p-4 bg-primary-200 dark:bg-primary-800/40 rounded-lg">
-                        <div className="bg-primary-700 text-white rounded-full w-8 h-8 flex items-center justify-center font-bold">3</div>
-                        <div>
-                          <h4 className="font-bold text-primary-900 dark:text-primary-100">Zero the Encoder</h4>
-                          <p className="text-primary-800 dark:text-primary-200 text-sm">Put arm to zero position, then in TunerX go to &quot;Info&quot; → press &quot;0 encoder&quot; button → press &quot;Apply&quot; button.</p>
-                        </div>
-                      </div>
-                    </div>
+                    <StepList
+                      variant="numbered"
+                      className="space-y-4"
+                      steps={[
+                        (
+                          <div
+                            key="rotate"
+                            className="flex items-center gap-4 p-4 bg-primary-50 dark:bg-primary-950/20 rounded-lg"
+                          >
+                            <div>
+                              <h4 className="font-bold text-primary-700 dark:text-primary-300">Rotate Counter-Clockwise</h4>
+                              <p className="text-primary-600 dark:text-primary-400 text-sm">
+                                Manually rotate the mechanism counter-clockwise and observe if the encoder position increases.
+                              </p>
+                            </div>
+                          </div>
+                        ),
+                        (
+                          <div
+                            key="fix-direction"
+                            className="flex items-center gap-4 p-4 bg-primary-100 dark:bg-primary-900/30 rounded-lg"
+                          >
+                            <div>
+                              <h4 className="font-bold text-primary-800 dark:text-primary-200">Fix Direction if Needed</h4>
+                              <p className="text-primary-700 dark:text-primary-300 text-sm">
+                                If position goes down instead of up, go to &quot;Info&quot; → &quot;Sensor Direction&quot; → press &quot;Apply&quot; button to invert the encoder direction.
+                              </p>
+                            </div>
+                          </div>
+                        ),
+                        (
+                          <div
+                            key="zero"
+                            className="flex items-center gap-4 p-4 bg-primary-200 dark:bg-primary-800/40 rounded-lg"
+                          >
+                            <div>
+                              <h4 className="font-bold text-primary-900 dark:text-primary-100">Zero the Encoder</h4>
+                              <p className="text-primary-800 dark:text-primary-200 text-sm">
+                                Put arm to zero position, then in TunerX go to &quot;Info&quot; → press &quot;0 encoder&quot; button → press &quot;Apply&quot; button.
+                              </p>
+                            </div>
+                          </div>
+                        ),
+                      ]}
+                    />
                   </div>
 
                   <iframe

--- a/src/components/StepList.tsx
+++ b/src/components/StepList.tsx
@@ -1,0 +1,37 @@
+import { ReactNode } from "react";
+
+interface StepListProps {
+  steps: ReactNode[];
+  variant?: "numbered" | "checkmark";
+  className?: string;
+}
+
+export default function StepList({
+  steps,
+  variant = "numbered",
+  className = "",
+}: StepListProps) {
+  if (variant === "checkmark") {
+    return (
+      <div className={`space-y-4 ${className}`}>
+        {steps.map((step, index) => (
+          <div key={index} className="flex items-start space-x-3">
+            <span className="bg-green-500 text-white rounded-full w-6 h-6 flex items-center justify-center text-sm font-bold">
+              ✓
+            </span>
+            <div>{step}</div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <ol className={`list-decimal list-inside space-y-2 ${className}`}>
+      {steps.map((step, index) => (
+        <li key={index}>{step}</li>
+      ))}
+    </ol>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `StepList` component that supports numbered and checkmark variants
- use `StepList` for CTRE hardware setup steps and Phoenix Tuner instructions
- apply `StepList` to mechanism setup implementation sequence

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68be946a9ea08332bc9261dd357213e4