### PR TITLE
feat: add reusable feature grid component

### DIFF
--- a/src/app/adding-commands/page.tsx
+++ b/src/app/adding-commands/page.tsx
@@ -1,7 +1,7 @@
 import MechanismTabs from "@/components/MechanismTabs";
 import GitHubPage from "@/components/GitHubPage";
 import PageTemplate from "@/components/PageTemplate";
-import ConceptBox from "@/components/ConceptBox";
+import FeatureGrid from "@/components/FeatureGrid";
 import CodeBlock from "@/components/CodeBlock";
 import KeyConceptSection from "@/components/KeyConceptSection";
 
@@ -85,28 +85,32 @@ public class RobotContainer {
         </details>
 
         {/* Key Concepts */}
-        <div className="grid md:grid-cols-3 gap-6">
-          <ConceptBox
-            title="🏠 Default Commands"
-            code={<code>setDefaultCommand(stopCommand());</code>}
-          >
-            Default commands run when no other command is using the subsystem. They are set in the subsystem constructor.
-          </ConceptBox>
-
-          <ConceptBox
-            title="🎮 Trigger Types"
-            code={<code>controller.a().whileTrue(command);</code>}
-          >
-            Different trigger types for different behaviors: onTrue (once), whileTrue (continuous), toggleOnTrue (toggle).
-          </ConceptBox>
-
-          <ConceptBox
-            title="🚀 Motor Configuration"
-            code={<code>motor.getConfigurator()<br/>&nbsp;&nbsp;&nbsp;&nbsp;.apply(config);</code>}
-          >
-            Motor configuration code should be wrapped properly to fit in configuration sections.
-          </ConceptBox>
-        </div>
+        <FeatureGrid
+          columns={3}
+          items={[
+            {
+              title: "🏠 Default Commands",
+              code: <code>setDefaultCommand(stopCommand());</code>,
+              content: (
+                <>Default commands run when no other command is using the subsystem. They are set in the subsystem constructor.</>
+              ),
+            },
+            {
+              title: "🎮 Trigger Types",
+              code: <code>controller.a().whileTrue(command);</code>,
+              content: (
+                <>Different trigger types for different behaviors: onTrue (once), whileTrue (continuous), toggleOnTrue (toggle).</>
+              ),
+            },
+            {
+              title: "🚀 Motor Configuration",
+              code: <code>motor.getConfigurator()<br/>&nbsp;&nbsp;&nbsp;&nbsp;.apply(config);</code>,
+              content: (
+                <>Motor configuration code should be wrapped properly to fit in configuration sections.</>
+              ),
+            },
+          ]}
+        />
       </section>
 
       {/* Mechanism Implementation Tabs */}

--- a/src/app/building-subsystems/page.tsx
+++ b/src/app/building-subsystems/page.tsx
@@ -1,6 +1,6 @@
 import MechanismTabs from "@/components/MechanismTabs";
 import PageTemplate from "@/components/PageTemplate";
-import ConceptBox from "@/components/ConceptBox";
+import FeatureGrid from "@/components/FeatureGrid";
 import CodeBlock from "@/components/CodeBlock";
 import KeyConceptSection from "@/components/KeyConceptSection";
 
@@ -88,25 +88,38 @@ public class ExampleSubsystem extends SubsystemBase {
         </details>
 
         {/* Key Concepts Explanation */}
-        <div className="grid md:grid-cols-3 gap-6">
-          <ConceptBox title="🔧 Hardware Instantiation" code={<code>TalonFX motor = new TalonFX(1);</code>}>
-            Motors, sensors, and other hardware objects are declared as private fields at the top of the class.
-          </ConceptBox>
-
-          <ConceptBox
-            title="⚙️ Configuration Location"
-            code={<code>motor.getConfigurator()<br/>&nbsp;&nbsp;&nbsp;&nbsp;.apply(config);</code>}
-          >
-            Motor configurations, current limits, and mode settings go in the constructor to run once at startup.
-          </ConceptBox>
-
-          <ConceptBox
-            title="🔄 Periodic Method"
-            code={<code>SmartDashboard.putNumber(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&quot;Value&quot;, sensor.get());</code>}
-          >
-            Runs every 20ms (50Hz). Use for telemetry, monitoring, and updating dashboard values - not for control!
-          </ConceptBox>
-        </div>
+        <FeatureGrid
+          columns={3}
+          items={[
+            {
+              title: "🔧 Hardware Instantiation",
+              code: <code>TalonFX motor = new TalonFX(1);</code>,
+              content: (
+                <>
+                  Motors, sensors, and other hardware objects are declared as private fields at the top of the class.
+                </>
+              ),
+            },
+            {
+              title: "⚙️ Configuration Location",
+              code: <code>motor.getConfigurator()<br/>&nbsp;&nbsp;&nbsp;&nbsp;.apply(config);</code>,
+              content: (
+                <>
+                  Motor configurations, current limits, and mode settings go in the constructor to run once at startup.
+                </>
+              ),
+            },
+            {
+              title: "🔄 Periodic Method",
+              code: <code>SmartDashboard.putNumber(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&quot;Value&quot;, sensor.get());</code>,
+              content: (
+                <>
+                  Runs every 20ms (50Hz). Use for telemetry, monitoring, and updating dashboard values - not for control!
+                </>
+              ),
+            },
+          ]}
+        />
 
       </section>
 

--- a/src/app/command-framework/page.tsx
+++ b/src/app/command-framework/page.tsx
@@ -1,6 +1,6 @@
 import PageTemplate from "@/components/PageTemplate";
 import KeyConceptSection from "@/components/KeyConceptSection";
-import ConceptBox from "@/components/ConceptBox";
+import FeatureGrid from "@/components/FeatureGrid";
 
 export default function CommandFramework() {
   return (
@@ -16,28 +16,38 @@ export default function CommandFramework() {
         concept="Command-based programming is the format in which you will write your code."
       />
 
-      <div className="grid md:grid-cols-3 gap-6">
-        <ConceptBox
-          title="Triggers"
-          subtitle={<strong>Use BooleanSuppliers (True or False)</strong>}
-        >
-          Link inputs to commands (e.g., press button to drive forward, or use sensor to run Command automatically). All buttons/triggers on a game controller are considered &quot;Triggers&quot;.
-        </ConceptBox>
-
-        <ConceptBox
-          title="Subsystems"
-          subtitle={<strong>Hardware components and control logic</strong>}
-        >
-          (e.g., Drivetrain, Arm, or Flywheel). Motors and sensors are instantiated. Methods to pull data from sensors within the subsystem are defined.
-        </ConceptBox>
-
-        <ConceptBox
-          title="Commands"
-          subtitle={<strong>Use Runnables (void functions)</strong>}
-        >
-          Encapsulate robot actions (e.g., DriveForwardCommand, ShootBallCommand).
-        </ConceptBox>
-      </div>
+      <FeatureGrid
+        columns={3}
+        items={[
+          {
+            title: "Triggers",
+            subtitle: <strong>Use BooleanSuppliers (True or False)</strong>,
+            content: (
+              <>
+                Link inputs to commands (e.g., press button to drive forward, or use sensor to run Command automatically). All
+                buttons/triggers on a game controller are considered &quot;Triggers&quot;.
+              </>
+            ),
+          },
+          {
+            title: "Subsystems",
+            subtitle: <strong>Hardware components and control logic</strong>,
+            content: (
+              <>
+                (e.g., Drivetrain, Arm, or Flywheel). Motors and sensors are instantiated. Methods to pull data from sensors within
+                the subsystem are defined.
+              </>
+            ),
+          },
+          {
+            title: "Commands",
+            subtitle: <strong>Use Runnables (void functions)</strong>,
+            content: (
+              <>Encapsulate robot actions (e.g., DriveForwardCommand, ShootBallCommand).</>
+            ),
+          },
+        ]}
+      />
 
       <section className="flex flex-col gap-8">
         <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100">

--- a/src/app/pid-control/page.tsx
+++ b/src/app/pid-control/page.tsx
@@ -2,7 +2,7 @@ import MechanismTabs from "@/components/MechanismTabs";
 import PageTemplate from "@/components/PageTemplate";
 import CodeBlock from "@/components/CodeBlock";
 import KeyConceptSection from "@/components/KeyConceptSection";
-import ConceptBox from "@/components/ConceptBox";
+import FeatureGrid from "@/components/FeatureGrid";
 
 export default function PIDControl() {
   return (
@@ -24,49 +24,68 @@ export default function PIDControl() {
           Understanding PID Components
         </h2>
 
-        <div className="grid md:grid-cols-3 gap-6">
-          <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-red-500">
-            <h3 className="text-xl font-bold text-[var(--foreground)] mb-4">P - Proportional</h3>
-            <p className="text-[var(--foreground)] mb-4 text-sm">
-              <strong>Definition:</strong> &quot;The amount of output to apply per unit of error in the system&quot;
-            </p>
-              <div className="bg-[var(--muted)] text-[var(--muted-foreground)] p-4 rounded mb-3">
-              <code className="text-xs">Error = Target - Current</code><br/>
-              <code className="text-xs">P_Output = kP × Error</code>
-            </div>
-            <p className="text-[var(--foreground)] text-sm">
-              <strong>Behavior:</strong> Larger error = stronger correction. Provides immediate response but may cause oscillation.
-            </p>
-          </div>
-
-          <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-yellow-500">
-            <h3 className="text-xl font-bold text-[var(--foreground)] mb-4">I - Integral</h3>
-            <p className="text-[var(--foreground)] mb-4 text-sm">
-              <strong>Definition:</strong> &quot;The amount of output to apply per unit of error for every second of that error&quot;
-            </p>
-              <div className="bg-[var(--muted)] text-[var(--muted-foreground)] p-4 rounded mb-3">
-              <code className="text-xs">Accumulated_Error += Error × dt</code><br/>
-              <code className="text-xs">I_Output = kI × Accumulated_Error</code>
-            </div>
-            <p className="text-[var(--foreground)] text-sm">
-              <strong>Behavior:</strong> Eliminates steady-state error by accumulating past errors over time.
-            </p>
-          </div>
-
-          <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-blue-500">
-            <h3 className="text-xl font-bold text-[var(--foreground)] mb-4">D - Derivative</h3>
-            <p className="text-[var(--foreground)] mb-4 text-sm">
-              <strong>Definition:</strong> &quot;The amount of output to apply per change in error over time&quot;
-            </p>
-              <div className="bg-[var(--muted)] text-[var(--muted-foreground)] p-4 rounded mb-3">
-              <code className="text-xs">Error_Rate = (Error - Last_Error) / dt</code><br/>
-              <code className="text-xs">D_Output = kD × Error_Rate</code>
-            </div>
-            <p className="text-[var(--foreground)] text-sm">
-              <strong>Behavior:</strong> Reduces overshoot by predicting future error trends and dampening response.
-            </p>
-          </div>
-        </div>
+        <FeatureGrid
+          columns={3}
+          items={[
+            {
+              title: "P - Proportional",
+              borderColorClass: "border-red-500",
+              content: (
+                <>
+                  <p className="text-[var(--foreground)] mb-4 text-sm">
+                    <strong>Definition:</strong> &quot;The amount of output to apply per unit of error in the system&quot;
+                  </p>
+                  <div className="bg-[var(--muted)] text-[var(--muted-foreground)] p-4 rounded mb-3">
+                    <code className="text-xs">Error = Target - Current</code>
+                    <br />
+                    <code className="text-xs">P_Output = kP × Error</code>
+                  </div>
+                  <p className="text-[var(--foreground)] text-sm">
+                    <strong>Behavior:</strong> Larger error = stronger correction. Provides immediate response but may cause oscillation.
+                  </p>
+                </>
+              ),
+            },
+            {
+              title: "I - Integral",
+              borderColorClass: "border-yellow-500",
+              content: (
+                <>
+                  <p className="text-[var(--foreground)] mb-4 text-sm">
+                    <strong>Definition:</strong> &quot;The amount of output to apply per unit of error for every second of that error&quot;
+                  </p>
+                  <div className="bg-[var(--muted)] text-[var(--muted-foreground)] p-4 rounded mb-3">
+                    <code className="text-xs">Accumulated_Error += Error × dt</code>
+                    <br />
+                    <code className="text-xs">I_Output = kI × Accumulated_Error</code>
+                  </div>
+                  <p className="text-[var(--foreground)] text-sm">
+                    <strong>Behavior:</strong> Eliminates steady-state error by accumulating past errors over time.
+                  </p>
+                </>
+              ),
+            },
+            {
+              title: "D - Derivative",
+              borderColorClass: "border-blue-500",
+              content: (
+                <>
+                  <p className="text-[var(--foreground)] mb-4 text-sm">
+                    <strong>Definition:</strong> &quot;The amount of output to apply per change in error over time&quot;
+                  </p>
+                  <div className="bg-[var(--muted)] text-[var(--muted-foreground)] p-4 rounded mb-3">
+                    <code className="text-xs">Error_Rate = (Error - Last_Error) / dt</code>
+                    <br />
+                    <code className="text-xs">D_Output = kD × Error_Rate</code>
+                  </div>
+                  <p className="text-[var(--foreground)] text-sm">
+                    <strong>Behavior:</strong> Reduces overshoot by predicting future error trends and dampening response.
+                  </p>
+                </>
+              ),
+            },
+          ]}
+        />
 
         {/* Feedforward Components */}
         <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-[var(--border)]">
@@ -75,20 +94,35 @@ export default function PIDControl() {
             Feedforward gains help the system by predicting the required output based on the target, rather than reacting to error.
           </p>
           
-            <div className="grid md:grid-cols-4 gap-4">
-              <ConceptBox title="kS - Static">
-                Constant output to overcome friction and get the mechanism moving.
-              </ConceptBox>
-              <ConceptBox title="kG - Gravity">
-                Compensates for gravitational forces acting on the mechanism.
-              </ConceptBox>
-              <ConceptBox title="kV - Velocity">
-                Output applied per target velocity to maintain smooth motion.
-              </ConceptBox>
-              <ConceptBox title="kA - Acceleration">
-                Output applied per target acceleration for responsive movement.
-              </ConceptBox>
-            </div>
+            <FeatureGrid
+              columns={4}
+              items={[
+                {
+                  title: "kS - Static",
+                  content: <>
+                    Constant output to overcome friction and get the mechanism moving.
+                  </>,
+                },
+                {
+                  title: "kG - Gravity",
+                  content: <>
+                    Compensates for gravitational forces acting on the mechanism.
+                  </>,
+                },
+                {
+                  title: "kV - Velocity",
+                  content: <>
+                    Output applied per target velocity to maintain smooth motion.
+                  </>,
+                },
+                {
+                  title: "kA - Acceleration",
+                  content: <>
+                    Output applied per target acceleration for responsive movement.
+                  </>,
+                },
+              ]}
+            />
         </div>
 
         {/* Documentation Link */}

--- a/src/components/ConceptBox.tsx
+++ b/src/components/ConceptBox.tsx
@@ -5,6 +5,7 @@ interface ConceptBoxProps {
   subtitle?: ReactNode;
   children: ReactNode;
   code?: ReactNode;
+  borderColorClass?: string;
 }
 
 export default function ConceptBox({
@@ -12,9 +13,14 @@ export default function ConceptBox({
   subtitle,
   children,
   code,
+  borderColorClass,
 }: ConceptBoxProps) {
   return (
-    <div className="bg-[var(--muted)] rounded-lg p-6 border-l-4 border-[var(--border)]">
+    <div
+      className={`bg-[var(--muted)] rounded-lg p-6 border-l-4 ${
+        borderColorClass ?? "border-[var(--border)]"
+      }`}
+    >
       <h4 className="text-lg font-bold text-[var(--foreground)] mb-3">{title}</h4>
       {subtitle && (
         <p className="text-[var(--foreground)] text-sm font-semibold mb-3">{subtitle}</p>

--- a/src/components/FeatureGrid.tsx
+++ b/src/components/FeatureGrid.tsx
@@ -1,0 +1,43 @@
+import ConceptBox from "@/components/ConceptBox";
+import { ReactNode } from "react";
+
+interface FeatureItem {
+  title: ReactNode;
+  subtitle?: ReactNode;
+  content: ReactNode;
+  code?: ReactNode;
+  borderColorClass?: string;
+}
+
+interface FeatureGridProps {
+  items: FeatureItem[];
+  columns?: 1 | 2 | 3 | 4 | 5 | 6;
+}
+
+export default function FeatureGrid({ items, columns = 3 }: FeatureGridProps) {
+  const columnClassMap: Record<number, string> = {
+    1: "md:grid-cols-1",
+    2: "md:grid-cols-2",
+    3: "md:grid-cols-3",
+    4: "md:grid-cols-4",
+    5: "md:grid-cols-5",
+    6: "md:grid-cols-6",
+  };
+  const columnClass = columnClassMap[columns] ?? `md:grid-cols-${columns}`;
+  return (
+    <div className={`grid gap-6 ${columnClass}`}>
+      {items.map((item, idx) => (
+        <ConceptBox
+          key={idx}
+          title={item.title}
+          subtitle={item.subtitle}
+          code={item.code}
+          borderColorClass={item.borderColorClass}
+        >
+          {item.content}
+        </ConceptBox>
+      ))}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add FeatureGrid component for consistent concept layouts
- replace custom grids in subsystem, command, and PID pages with FeatureGrid
- allow ConceptBox border color customization

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68be946bd3bc8332882aa9fa250e4b4f