### PR TITLE
Add uniform troubleshooting footer to Workshop #1 pages

### DIFF
--- a/src/app/adding-commands/page.tsx
+++ b/src/app/adding-commands/page.tsx
@@ -4,6 +4,7 @@ import PageTemplate from "@/components/PageTemplate";
 import ConceptBox from "@/components/ConceptBox";
 import CodeBlock from "@/components/CodeBlock";
 import KeyConceptSection from "@/components/KeyConceptSection";
+import WorkshopFooter from "@/components/WorkshopFooter";
 
 export default function AddingCommands() {
   return (
@@ -198,6 +199,14 @@ public class RobotContainer {
           </div>
         </details>
       </section>
+      <WorkshopFooter
+        next={{
+          href: "/running-program",
+          title: "Running Program",
+          description: "Run the project on your robot to test behavior.",
+        }}
+        relatedLinks={[{ href: "/building-subsystems", label: "Subsystems" }]}
+      />
     </PageTemplate>
   );
 }

--- a/src/app/building-subsystems/page.tsx
+++ b/src/app/building-subsystems/page.tsx
@@ -3,6 +3,7 @@ import PageTemplate from "@/components/PageTemplate";
 import ConceptBox from "@/components/ConceptBox";
 import CodeBlock from "@/components/CodeBlock";
 import KeyConceptSection from "@/components/KeyConceptSection";
+import WorkshopFooter from "@/components/WorkshopFooter";
 
 export default function BuildingSubsystems() {
   return (
@@ -200,6 +201,18 @@ public class ExampleSubsystem extends SubsystemBase {
           },
           nextStepText: "This flywheel subsystem is ready for command integration! Next, we'll add commands to control this Flywheel subsystem through user input."
         }}
+      />
+      <WorkshopFooter
+        next={{
+          href: "/adding-commands",
+          title: "Commands",
+          description:
+            "Add commands to interact with your subsystems.",
+        }}
+        relatedLinks={[{
+          href: "/command-framework",
+          label: "Command-Based Framework",
+        }]}
       />
     </PageTemplate>
   );

--- a/src/app/command-framework/page.tsx
+++ b/src/app/command-framework/page.tsx
@@ -1,6 +1,7 @@
 import PageTemplate from "@/components/PageTemplate";
 import KeyConceptSection from "@/components/KeyConceptSection";
 import ConceptBox from "@/components/ConceptBox";
+import WorkshopFooter from "@/components/WorkshopFooter";
 
 export default function CommandFramework() {
   return (
@@ -110,6 +111,15 @@ export default function CommandFramework() {
           </a>
         </div>
       </section>
-    </PageTemplate>
-  );
-}
+        <WorkshopFooter
+          next={{
+            href: "/building-subsystems",
+            title: "Building Subsystems",
+            description:
+              "Build subsystems to structure robot hardware control.",
+          }}
+          relatedLinks={[{ href: "/project-setup", label: "Project Setup" }]}
+        />
+      </PageTemplate>
+    );
+  }

--- a/src/app/hardware/page.tsx
+++ b/src/app/hardware/page.tsx
@@ -2,6 +2,7 @@ import PageTemplate from "@/components/PageTemplate";
 import ImageBlock from "@/components/ImageBlock";
 import KeyConceptSection from "@/components/KeyConceptSection";
 import ContentCard from "@/components/ContentCard";
+import WorkshopFooter from "@/components/WorkshopFooter";
 
 export default function Hardware() {
   return (
@@ -453,6 +454,15 @@ export default function Hardware() {
           className="w-full h-full aspect-video rounded-lg"
         />
       </section>
+      <WorkshopFooter
+        next={{
+          href: "/project-setup",
+          title: "Project Setup",
+          description:
+            "Set up your WPILib project and install dependencies.",
+        }}
+        relatedLinks={[{ href: "/mechanism-cad", label: "Mechanism CAD" }]}
+      />
     </PageTemplate>
   );
 }

--- a/src/app/mechanism-setup/page.tsx
+++ b/src/app/mechanism-setup/page.tsx
@@ -5,6 +5,7 @@ import PageTemplate from "@/components/PageTemplate";
 import ImageBlock from "@/components/ImageBlock";
 import KeyConceptSection from "@/components/KeyConceptSection";
 import ConceptBox from "@/components/ConceptBox";
+import WorkshopFooter from "@/components/WorkshopFooter";
 
 export default function MechanismSetup() {
   const [activeTab, setActiveTab] = useState<"arm" | "flywheel">("arm");
@@ -323,6 +324,15 @@ export default function MechanismSetup() {
           </p>
         </div>
       </div>
+      <WorkshopFooter
+        next={{
+          href: "/pid-control",
+          title: "PID Control",
+          description:
+            "Learn the fundamentals of PID control for precise motion.",
+        }}
+        relatedLinks={[{ href: "/running-program", label: "Running Program" }]}
+      />
     </PageTemplate>
   );
 }

--- a/src/app/motion-magic/page.tsx
+++ b/src/app/motion-magic/page.tsx
@@ -2,6 +2,7 @@ import MechanismTabs from "@/components/MechanismTabs";
 import PageTemplate from "@/components/PageTemplate";
 import CodeBlock from "@/components/CodeBlock";
 import KeyConceptSection from "@/components/KeyConceptSection";
+import WorkshopFooter from "@/components/WorkshopFooter";
 
 export default function MotionMagic() {
   return (
@@ -293,6 +294,15 @@ public void setTargetPosition(double positionRotations) {
           </div>
         </details>
       </section>
+      <WorkshopFooter
+        next={{
+          href: "/",
+          title: "Home",
+          description:
+            "Return to the home page to explore additional resources and workshops.",
+        }}
+        relatedLinks={[{ href: "/pid-control", label: "PID Control" }]}
+      />
     </PageTemplate>
   );
 }

--- a/src/app/pid-control/page.tsx
+++ b/src/app/pid-control/page.tsx
@@ -3,6 +3,7 @@ import PageTemplate from "@/components/PageTemplate";
 import CodeBlock from "@/components/CodeBlock";
 import KeyConceptSection from "@/components/KeyConceptSection";
 import ConceptBox from "@/components/ConceptBox";
+import WorkshopFooter from "@/components/WorkshopFooter";
 
 export default function PIDControl() {
   return (
@@ -237,6 +238,14 @@ public void setTargetPosition(double positionRotations) {
         />
 
       </section>
+      <WorkshopFooter
+        next={{
+          href: "/motion-magic",
+          title: "Motion Magic",
+          description: "Use Motion Magic to simplify complex movements.",
+        }}
+        relatedLinks={[{ href: "/mechanism-setup", label: "Mechanism Setup" }]}
+      />
     </PageTemplate>
   );
 }

--- a/src/app/project-setup/page.tsx
+++ b/src/app/project-setup/page.tsx
@@ -1,5 +1,6 @@
 import PageTemplate from "@/components/PageTemplate";
 import KeyConceptSection from "@/components/KeyConceptSection";
+import WorkshopFooter from "@/components/WorkshopFooter";
 
 export default function ProjectSetup() {
   return (
@@ -145,6 +146,15 @@ export default function ProjectSetup() {
           <strong>💡 Next Step:</strong> After creating your project, you&apos;ll learn about the Command-Based Framework in the next section. Your project will be ready for implementing subsystems and commands!
         </p>
       </div>
+      <WorkshopFooter
+        next={{
+          href: "/command-framework",
+          title: "Command-Based Framework",
+          description:
+            "Discover how the command-based framework organizes robot code.",
+        }}
+        relatedLinks={[{ href: "/hardware", label: "Hardware Setup" }]}
+      />
     </PageTemplate>
   );
 }

--- a/src/app/running-program/page.tsx
+++ b/src/app/running-program/page.tsx
@@ -1,5 +1,6 @@
 import PageTemplate from "@/components/PageTemplate";
 import KeyConceptSection from "@/components/KeyConceptSection";
+import WorkshopFooter from "@/components/WorkshopFooter";
 
 export default function RunningProgram() {
   return (
@@ -49,6 +50,15 @@ export default function RunningProgram() {
           className="w-full h-full aspect-video rounded-lg"
         />
       </section>
+      <WorkshopFooter
+        next={{
+          href: "/mechanism-setup",
+          title: "Mechanism Setup",
+          description:
+            "Prepare mechanisms for integration with the robot code.",
+        }}
+        relatedLinks={[{ href: "/adding-commands", label: "Commands" }]}
+      />
     </PageTemplate>
   );
 }

--- a/src/components/WorkshopFooter.tsx
+++ b/src/components/WorkshopFooter.tsx
@@ -1,0 +1,75 @@
+import Link from "next/link";
+
+interface NextInfo {
+  href: string;
+  title: string;
+  description: string;
+}
+
+interface RelatedLink {
+  href: string;
+  label: string;
+}
+
+interface WorkshopFooterProps {
+  next: NextInfo;
+  relatedLinks: RelatedLink[];
+}
+
+export default function WorkshopFooter({ next, relatedLinks }: WorkshopFooterProps) {
+  return (
+    <section className="flex flex-col gap-8 mt-12">
+      <div className="bg-red-100 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-6">
+        <h3 className="text-lg font-semibold text-red-700 dark:text-red-300 mb-3">
+          🚧 Common Mistakes
+        </h3>
+        <ul className="list-disc list-inside space-y-2 text-red-800 dark:text-red-300">
+          <li>Skipping required setup steps.</li>
+          <li>Using outdated or mismatched firmware versions.</li>
+        </ul>
+      </div>
+
+      <div className="bg-slate-50 dark:bg-slate-900 rounded-lg p-6 border border-slate-200 dark:border-slate-800">
+        <h3 className="text-xl font-semibold text-slate-900 dark:text-slate-100 mb-4">
+          Troubleshooting
+        </h3>
+        <ul className="list-disc list-inside space-y-2 text-slate-600 dark:text-slate-300">
+          <li>Review wiring and connections before testing.</li>
+          <li>Check console logs for error messages.</li>
+          <li>Consult the documentation when unexpected behavior occurs.</li>
+        </ul>
+      </div>
+
+      <div className="bg-primary-50 dark:bg-primary-950/30 rounded-lg p-6 border border-slate-200 dark:border-slate-800">
+        <h3 className="text-xl font-semibold text-slate-900 dark:text-slate-100 mb-3">
+          What&apos;s Next?
+        </h3>
+        <p className="text-slate-600 dark:text-slate-300 mb-4">{next.description}</p>
+        <Link
+          href={next.href}
+          className="text-primary-600 underline hover:no-underline dark:text-primary-400"
+        >
+          Continue to {next.title} →
+        </Link>
+      </div>
+
+      <div className="bg-slate-50 dark:bg-slate-900 rounded-lg p-6 border border-slate-200 dark:border-slate-800">
+        <h3 className="text-xl font-semibold text-slate-900 dark:text-slate-100 mb-4">
+          Related Concepts
+        </h3>
+        <ul className="list-disc list-inside space-y-2 text-slate-600 dark:text-slate-300">
+          {relatedLinks.map((link) => (
+            <li key={link.href}>
+              <Link
+                href={link.href}
+                className="text-primary-600 underline hover:no-underline dark:text-primary-400"
+              >
+                {link.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- provide a shared `WorkshopFooter` component with common mistakes, troubleshooting tips, next steps, and related links
- attach the footer to each Workshop #1 page for consistent guidance and navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68be963faedc83328b1efb8612f9a840