### PR TITLE
fix: close AlertBox tag on PID control page

### DIFF
--- a/src/app/pid-control/page.tsx
+++ b/src/app/pid-control/page.tsx
@@ -102,7 +102,7 @@ export default function PIDControl() {
             title="CTRE Manual PID Tuning Guide"
             icon="📖"
           />
-        </div>
+        </AlertBox>
       </section>
 
       {/* Code Implementation */}


### PR DESCRIPTION
## Summary
- close AlertBox JSX tag on PID control page to resolve build parsing error

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68be9de5a2008332825c4fbb16d22c9e