### PR TITLE
Embed flywheel follower motor caution

### DIFF
--- a/src/app/building-subsystems/page.tsx
+++ b/src/app/building-subsystems/page.tsx
@@ -114,34 +114,6 @@ public class ExampleSubsystem extends SubsystemBase {
 
       </section>
 
-      {/* Follower Motor Caution */}
-      <AlertBox
-        variant="warning"
-        icon={
-          <svg
-            className="w-6 h-6"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.732-.833-2.464 0L4.35 16.5c-.77.833.192 2.5 1.732 2.5z"
-            />
-          </svg>
-        }
-        title="Caution: Physical Hardware vs Code Example"
-      >
-        <p className="mb-3">
-          The flywheel device built in this workshop does <strong>not</strong> have a physical follower motor. However, the following code examples include a follower motor setup to demonstrate best practices for multi-motor subsystems.
-        </p>
-        <AlertBox variant="warning" title="Note" className="mt-3">
-          If implementing on actual hardware, you would either remove the follower motor code or add a second physical motor to your flywheel mechanism.
-        </AlertBox>
-      </AlertBox>
-
       {/* Mechanism Implementation Tabs */}
       <MechanismTabs
         sectionTitle="Workshop Implementation"
@@ -205,11 +177,40 @@ public class ExampleSubsystem extends SubsystemBase {
             rightTitle: "Key Methods",
             rightItems: [
               "• <strong>setVoltage():</strong> Direct voltage control for flywheel speed",
-              "• <strong>stop():</strong> Safe motor stop with neutral output", 
+              "• <strong>stop():</strong> Safe motor stop with neutral output",
               "• <strong>periodic():</strong> Understand that periodic runs every robot loop"
             ]
           },
-          nextStepText: "This flywheel subsystem is ready for command integration! Next, we'll add commands to control this Flywheel subsystem through user input."
+          nextStepText:
+            "This flywheel subsystem is ready for command integration! Next, we'll add commands to control this Flywheel subsystem through user input.",
+          caution: (
+            <AlertBox
+              variant="warning"
+              icon={
+                <svg
+                  className="w-6 h-6"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.732-.833-2.464 0L4.35 16.5c-.77.833.192 2.5 1.732 2.5z"
+                  />
+                </svg>
+              }
+              title="Caution: Physical Hardware vs Code Example"
+            >
+              <p className="mb-3">
+                The flywheel device built in this workshop does <strong>not</strong> have a physical follower motor. However, the following code examples include a follower motor setup to demonstrate best practices for multi-motor subsystems.
+              </p>
+              <AlertBox variant="warning" title="Note" className="mt-3">
+                If implementing on actual hardware, you would either remove the follower motor code or add a second physical motor to your flywheel mechanism.
+              </AlertBox>
+            </AlertBox>
+          )
         }}
       />
     </PageTemplate>

--- a/src/components/MechanismTabs.tsx
+++ b/src/components/MechanismTabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, ReactNode } from "react";
 import GithubPageWithPR from "./GithubPageWithPR";
 import CodeWalkthrough from "./CodeWalkthrough";
 import ComparisonTable from "./ComparisonTable";
@@ -20,6 +20,7 @@ interface MechanismContent {
     rightItems: string[];
   };
   nextStepText: string;
+  caution?: ReactNode;
 }
 
 interface MechanismTabsProps {
@@ -72,6 +73,9 @@ export default function MechanismTabs({
 
         {/* Tab Content */}
         <div className="p-6">
+          {currentContent.caution && (
+            <div className="mb-6">{currentContent.caution}</div>
+          )}
           {/* Before/After Implementation */}
           <div className="bg-slate-100 dark:bg-slate-800 rounded-lg p-6 mb-6">
             <h3 className="text-xl font-bold text-slate-900 dark:text-slate-100 mb-4">


### PR DESCRIPTION
## Summary
- allow MechanismTabs to show mechanism-specific cautions
- move follower motor caution into Flywheel example

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bea3b7d12c83329162b2e77df1b19d