### PR TITLE
Rewrite README to match the v3 site

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,494 +2,164 @@
 
 🌐 **Live Site: [frc5712.com](https://frc5712.com)**
 
-A responsive website built with Next.js and Tailwind CSS that converts the Gray Matter Coding Workshop Canva presentation into an accessible markdown-based learning platform.
+[![CI/CD Pipeline](https://github.com/Hemlock5712/Workshop-Site/workflows/CI/CD%20Pipeline/badge.svg)](https://github.com/Hemlock5712/Workshop-Site/actions)
+[![Deploy with Vercel](https://vercel.com/button)](https://frc5712.com)
 
-## 🎯 About
+An interactive FRC programming workshop built with Next.js and Tailwind CSS. The site walks teams from hardware setup through PID tuning, swerve drive, autonomous, logging, vision, and state machines — with live code embeds, interactive playgrounds, and video lessons.
 
-This website transforms the FRC programming workshop content into an interactive web experience, covering:
+## 🎯 What It Teaches
 
-- **Introduction & Prerequisites** - Getting started with FRC programming
-- **Hardware Setup** - CTRE motors, CANivore, and device configuration
-- **Project Setup** - Creating and organizing WPILib projects
-- **Command-Based Framework** - Understanding triggers, subsystems, and commands
-- **Control Systems** - PID and Feedforward control theory
-- **Tuning** - Real-world mechanism tuning with Phoenix Tuner X
-- **AI Assistant** - Ask questions and get answers about workshop content using Gemini AI
+All content targets the **WPILib 2027 alpha stack**, not the classic Commands v2 framework:
 
-## 🔗 Workshop Code Repository
+- **Commands v3 + OpModes** (`org.wpilib.command3`) — subsystems extend `Mechanism`; each mode is its own `@Teleop` / `@Autonomous` class with its bindings in the constructor. There is no `RobotContainer`.
+- **Java 25**, deploying to **SystemCore** (not roboRIO), with Phoenix 6 alpha and GradleRIO 2027 alpha.
+- **Command conventions**: commands are coroutine bodies built from mechanism factories — set-once, or set-and-hold with `coroutine.park()` — and composed by chaining, with every builder chain ending in `.named(...)`.
+- **Autonomous** uses CTRE `DriveToPose` and `LinearPath` — the workshop does not use PathPlanner.
+- **Logging** uses WPILib's `DataLogManager` — the workshop does not use AdvantageKit.
 
-The workshop includes live code examples from the companion repository:
-**[Workshop-Code](https://github.com/Hemlock5712/Workshop-Code)**
+Ground truth for all Java examples is the [2027-Template](https://github.com/Hemlock5712/2027-Template) repository. Lesson pages embed live files and PR diffs from the companion [Workshop-Code](https://github.com/Hemlock5712/Workshop-Code) repository, whose numbered branches build each mechanism step by step.
 
-### Implementation Progression
+## 📚 Curriculum
 
-The workshop follows a structured 5-step progression:
+Lesson order, sidebar grouping, and prev/next navigation all come from [`src/data/lessons.ts`](src/data/lessons.ts):
 
-1. **Step 1: Creating a Subsystem** - Basic motor control and sensor integration
-2. **Step 2: Adding Commands** - Command-based architecture and user input
-3. **Step 3: PID Control** - Precise position control with feedback loops
-4. **Step 4: Using Motion Magic** - Smooth profiled movements with acceleration control
-5. **Step 5: Useful Subsystem Functions** - Safety features, utilities, and diagnostics
+```
+Getting Started:
+├── /                        Homepage (team, mechanisms, overview)
+├── /introduction            Workshop introduction
+├── /prerequisites           Required software & hardware
+└── /mechanism-cad           CAD files and 3D models
 
-Each step builds upon the previous implementation, showing real-world development practices.
+Workshop #1:
+├── /hardware                CTRE hardware setup
+├── /project-setup           WPILib project creation
+├── /command-framework       Command-Based Framework (Commands v3 concepts)
+├── /building-subsystems     Mechanisms
+├── /adding-commands         Commands
+├── /triggers                Triggers
+├── /running-program         Run code with hardware sim
+├── /mechanism-setup         Mechanism selection & setup
+├── /pid-control             PID control + interactive playground
+└── /motion-magic            Motion Magic profiled movement
+
+Workshop #2:
+├── /swerve-prerequisites    Swerve drive prerequisites
+├── /swerve-drive-project    Creating a swerve drive project
+├── /pathplanner             Autonomous: Driving to a Pose (CTRE DriveToPose —
+│                            the slug is historical; the page no longer teaches PathPlanner)
+├── /swerve-calibration      Swerve calibration
+├── /logging-options         Logging strategies (DataLogManager)
+├── /logging-implementation  Logging system setup
+├── /drive-to-point          Drive to point navigation with PID
+├── /vision-options          Computer vision approaches
+└── /vision-implementation   Vision system integration
+
+Advanced Topics:
+├── /vision-shooting         Dynamic Flywheel Control
+├── /state-based             State Machines (command3 StateMachine)
+└── /advanced-drive-to-point Advanced: Profiled Drive to Point (LinearPath)
+
+Utility pages (outside lesson navigation):
+└── /search, /glossary, /ai-assistant, /planner, /privacy
+```
 
 ## 🚀 Getting Started
 
-### Requirements
-
-- Node.js 20+
-- Optional: [Bun](https://bun.sh/) v1+ for alternative package management
-
-Project uses **pnpm** by default, but npm/yarn/bun work interchangeably.
-
-First, run the development server:
+Requires Node.js 20+. The project uses **pnpm** by default, but npm/yarn/bun work interchangeably.
 
 ```bash
+pnpm install
 pnpm dev
-# or
-npm run dev
-# or
-yarn dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000) in your browser.
 
 ### Development Commands
 
 - `pnpm dev` – start the local development server with Turbopack
-- `pnpm build` – build for production (includes search generation and formatting)
+- `pnpm build` – build for production (regenerates the search index first)
 - `pnpm start` – start the production server
 - `pnpm lint` – lint code with ESLint
 - `pnpm type-check` – check TypeScript types
-- `pnpm format` – format code with Prettier
-- `pnpm format:check` – check code formatting without writing
-- `pnpm generate-search` – update search index data
-- `pnpm spell` – run spell check on TypeScript and markdown files
-- `pnpm test` – run full test suite (format:check + lint + type-check + build)
+- `pnpm format` / `pnpm format:check` – format code with Prettier / check only
+- `pnpm generate-search` – regenerate the search index (`src/data/searchData.ts`)
+- `pnpm spell` – spell-check TypeScript and markdown files
+- `pnpm test` – full suite: format:check + lint + type-check + build
 
-**Note:** You can substitute `npm`, `yarn`, or `bun` for `pnpm` in any command.
+After editing page content, run `pnpm generate-search` and then `pnpm format` — the search index is regenerated unformatted, and `format:check` will fail otherwise.
 
 ## 🛠 Tech Stack
 
-- **Framework:** Next.js 15.4.6 with App Router
-- **UI Library:** React 19.1.0
-- **Styling:** Tailwind CSS 4
+- **Framework:** Next.js 16 with App Router
+- **UI:** React 19, Tailwind CSS 4 (dark mode via next-themes)
 - **Language:** TypeScript
+- **Search:** MiniSearch fuzzy search
 - **Deployment:** Vercel
 
 ## 📁 Project Structure
 
 ```
 src/
-├── app/                           # Next.js App Router pages
-│   ├── introduction/              # Workshop introduction
-│   ├── prerequisites/             # Required software & hardware
-│   ├── mechanism-setup/           # Mechanism selection & setup
-│   ├── mechanism-cad/             # CAD files and 3D modeling
-│   ├── hardware/                  # Hardware setup guide
-│   ├── project-setup/             # Project creation & organization
-│   ├── building-subsystems/       # Creating subsystem architecture
-│   ├── adding-commands/           # Command-based programming
-│   ├── triggers/                  # Button and trigger configuration
-│   ├── command-framework/         # Advanced command patterns
-│   ├── running-program/           # Run code with hardware sim
-│   ├── state-based/               # State machine control
-│   ├── pid-control/               # PID controller implementation
-│   ├── motion-magic/              # Motion Magic profiled movement
-│   ├── pathplanner/               # PathPlanner trajectory following
-│   ├── swerve-drive-project/      # Swerve drive implementation
-│   ├── vision-options/            # Computer vision approaches
-│   ├── vision-implementation/     # Vision system integration
-│   ├── vision-shooting/           # Vision-based shooting
-│   ├── logging-options/           # Data logging strategies
-│   ├── logging-implementation/    # Logging system setup
-│   ├── search/                    # Search functionality page
-│   ├── ai-assistant/              # AI-powered Q&A assistant
-│   └── api/
-│       └── gemini/                # Gemini API endpoint for AI assistant
-├── components/                    # Reusable React components
-│   ├── Sidebar.tsx                # Collapsible navigation sidebar
-│   ├── PageTemplate.tsx           # Shared page layout
-│   ├── SearchBar.tsx              # MiniSearch-powered search
-│   ├── theme-provider.tsx         # next-themes provider wrapper
-│   ├── ui/
-│   │   └── animated-theme-toggler.tsx # Animated dark/light theme toggle
-│   ├── CodeBlock.tsx              # IDE-style syntax highlighted code
-│   ├── CodeWalkthrough.tsx        # Step-by-step code explanation
-│   ├── GitHubContent.tsx          # Live GitHub file viewer + optional PR diff tab
-│   ├── ImageBlock.tsx             # Optimized image display
-│   ├── AlertBox.tsx               # Styled alert/warning boxes
-│   ├── BillOfMaterials.tsx        # Hardware BOM table component
-│   ├── CollapsibleSection.tsx     # Expandable content sections
-│   ├── ComparisonTable.tsx        # Side-by-side comparison tables
-│   ├── ConceptBox.tsx             # Highlighted concept explanation boxes
-│   ├── ContentCard.tsx            # Card-based content layout
-│   ├── KeyConceptSection.tsx      # Key learning point sections
-│   ├── MechanismTabs.tsx          # Tabbed mechanism selection interface
-│   ├── ModelViewer.tsx            # 3D model display with Three.js
-│   ├── AutoFocusMain.tsx          # Automatic focus management for main content
-│   ├── ComingSoonPage.tsx         # Template for upcoming features
-│   ├── DocumentationButton.tsx    # Quick access to external documentation
-│   ├── KeyboardNavigationProvider.tsx # Context provider for keyboard shortcuts
-│   └── KeyboardShortcutsHelp.tsx  # Modal displaying available keyboard shortcuts
-├── data/                          # Static data and configuration
-│   ├── searchData.ts              # Search index for all content
-│   ├── armBOM.ts                  # Arm mechanism bill of materials
-│   └── shooterBOM.ts              # Shooter mechanism bill of materials
-├── hooks/                         # Custom React hooks
-│   └── useKeyboardNavigation.ts   # Keyboard navigation functionality
-└── lib/                          # Utility libraries
-    └── searchConfig.ts            # MiniSearch configuration
+├── app/
+│   ├── (workshop)/          # All lesson & utility pages (one folder per route)
+│   ├── (planner)/planner/   # Season planner tool
+│   ├── api/chat/            # AI assistant endpoint (Gemini + File Search)
+│   ├── api/github/          # File fetcher for live Workshop-Code embeds
+│   ├── video/               # Unlisted preview page for workshop videos
+│   └── layout.tsx           # Root layout (theme, sidebar, search bar)
+├── components/              # Sidebar, PageTemplate, GitHubContent, Box,
+│                            # interactive playgrounds, quizzes, planner UI…
+├── data/                    # lessons.ts (navigation source of truth),
+│                            # searchData.ts, bills of materials
+├── lib/                     # Search config, playground physics, planner logic
+├── hooks/                   # Keyboard navigation, planner hooks
+└── contexts/                # Sidebar state
+scripts/                     # Search index generator + File Search indexers
+videos/                      # Remotion project that renders the workshop videos
+context/                     # Design principles and style guide
+public/                      # Images, 3D models, downloads
 ```
 
-## 🤖 GitHub Actions CI/CD
+Navigation (sidebar groups, lesson order, prev/next links) is derived entirely from `src/data/lessons.ts` — add or reorder lessons there. See [CLAUDE.md](CLAUDE.md) for the full architecture and content-authoring reference.
 
-This project includes automated workflows for quality assurance and deployment:
+## 🤖 AI Assistant (Optional)
 
-### CI Pipeline
+The `/ai-assistant` page answers workshop questions using Gemini with a File Search store for retrieval. Everything else works without it. To enable it locally:
 
-The GitHub Actions workflow (`.github/workflows/ci.yml`) automatically:
+1. Create `.env.local` with a [Google AI Studio](https://aistudio.google.com/app/apikey) API key:
 
-- ✅ **Lints code** with ESLint for style consistency
-- 🔍 **Type checks** with TypeScript for type safety
-- 🏗️ **Builds project** to ensure compilation success
-- 📦 **Uploads artifacts** for deployment verification
+   ```
+   GOOGLE_GENERATIVE_AI_API_KEY=your_api_key
+   GEMINI_FILE_SEARCH_STORE=your_store_name
+   ```
 
-### Workflow Triggers
-
-- **Push to main/master** - Full CI pipeline + deployment readiness check
-- **Pull Requests** - CI pipeline for code quality verification
-- **Manual trigger** - Can be run manually from GitHub Actions tab
-
-### Status Badges
-
-[![CI/CD Pipeline](https://github.com/Hemlock5712/Workshop-Site/workflows/CI/CD%20Pipeline/badge.svg)](https://github.com/Hemlock5712/Workshop-Site/actions)
-[![Deploy with Vercel](https://vercel.com/button)](https://frc5712.com)
-
-## 🌐 Live Deployment
-
-**🚀 Live Site:** [frc5712.com](https://frc5712.com)
-
-### Automatic Deployment
-
-This project is automatically deployed to Vercel:
-
-- **Repository:** [https://github.com/Hemlock5712/Workshop-Site](https://github.com/Hemlock5712/Workshop-Site)
-- **Production Branch:** `master`
-- **Auto-deploy:** Every push to `master` triggers a new deployment
-- **Preview Deployments:** Pull requests create preview deployments
-- **Quality Gates:** GitHub Actions ensure code quality before deployment
-
-### Deploy Your Own
-
-1. **Fork this repository** to your GitHub account
-2. **Connect to Vercel:**
-   - Visit [vercel.com](https://vercel.com)
-   - Sign in with GitHub
-   - Import your forked repository
-   - Deploy automatically
-
-### Manual Deployment
-
-1. Install Vercel CLI: `pnpm add -g vercel` or `npm i -g vercel`
-2. Run `vercel` in the project directory
-3. Follow the prompts to deploy
-
-### Environment Setup
-
-For the AI Assistant feature:
-
-1. Copy `.env.example` to `.env.local`:
+2. One-time store creation (prints the store name for `.env.local`):
 
    ```bash
-   cp .env.example .env.local
+   npx tsx scripts/setup-file-search.ts
    ```
 
-2. Get a Gemini API key from [Google AI Studio](https://aistudio.google.com/app/apikey)
-
-3. Add your API key to `.env.local`:
-   ```
-   GOOGLE_GENERATIVE_AI_API_KEY=your_actual_api_key_here
-   ```
-
-**Note:** The AI Assistant is optional. Without the API key, all other features work normally.
-
-## 🤖 Adding Content to Convex (AI Assistant Knowledge Base)
-
-The AI Assistant uses Convex as a vector database to store and search workshop content. To add new information that the AI can reference:
-
-### Required Setup
-
-1. **Install Convex CLI** (if not already installed):
+3. Upload workshop pages to the store (use `--replace` after content changes):
 
    ```bash
-   npm install -g convex
+   npx tsx scripts/upload-to-file-search.ts
    ```
 
-2. **Set up environment variables** in `.env.local`:
-   ```bash
-   GOOGLE_GENERATIVE_AI_API_KEY=your_gemini_api_key_here
-   NEXT_PUBLIC_CONVEX_URL=your_convex_deployment_url
-   ```
+`scripts/list-file-search.ts` lists what the store currently contains.
 
-### Using the Indexing Scripts
+## 🌐 Deployment
 
-The project includes three automated indexers to populate Convex with content:
+The site auto-deploys to Vercel: every push to `master` ships to [frc5712.com](https://frc5712.com), and pull requests get preview deployments. GitHub Actions (`.github/workflows/ci.yml`) runs lint, type-check, spell-check, and build on every push and PR.
 
-#### 1. **Workshop Pages Indexer**
-
-Indexes all workshop pages from the site into Convex.
-
-```bash
-# Index all workshop pages (recommended)
-npx tsx scripts/rag/workshop-indexer.ts
-
-# Pilot mode (subset for testing)
-npx tsx scripts/rag/workshop-indexer.ts --pilot
-```
-
-**What it indexes:**
-
-- All 24+ workshop pages (/, /hardware, /building-subsystems, etc.)
-- Extracts text content from each page
-- Creates semantic chunks with proper context
-- Generates embeddings and uploads to Convex
-
-#### 2. **External Documentation Indexer**
-
-Scrapes and indexes external documentation referenced in the workshop.
-
-```bash
-npx tsx scripts/rag/external-docs-indexer.ts
-```
-
-**What it indexes:**
-
-- CTRE Phoenix 6 documentation
-- WPILib documentation
-- PathPlanner documentation
-- Limelight documentation
-- PhotonVision documentation
-
-**Note:** Requires internet connection to scrape external sites.
-
-#### 3. **Code Repository Indexer**
-
-Indexes Java code from GitHub repositories (Workshop-Code).
-
-```bash
-# Pilot mode (Workshop-Code main branch only)
-npx tsx scripts/rag/code-indexer.ts --pilot
-
-# Full mode (all configured repositories)
-npx tsx scripts/rag/code-indexer.ts
-```
-
-**What it indexes:**
-
-- Java files from Workshop-Code repository
-- Smart code-aware chunking (keeps methods intact)
-- Preserves class context and imports
-- Includes GitHub URLs for reference
-
-**Optional:** Add `GITHUB_TOKEN` to `.env.local` to increase API rate limits (5000/hr vs 60/hr).
-
-#### Full Indexing Workflow
-
-To populate Convex with all content:
-
-```bash
-# 1. Index workshop pages
-npx tsx scripts/rag/workshop-indexer.ts
-
-# 2. Index external documentation
-npx tsx scripts/rag/external-docs-indexer.ts
-
-# 3. Index code repositories
-npx tsx scripts/rag/code-indexer.ts
-
-# 4. Verify with stats
-npx tsx scripts/rag/test-retrieval.ts
-```
-
-**Expected Results:**
-
-- Workshop pages: ~60 chunks
-- External docs: ~80 chunks
-- Code: ~90 chunks
-- **Total: ~230 chunks**
-
-#### Configuration
-
-Edit indexer configurations in:
-
-- `scripts/rag/workshop-indexer.ts` - Workshop pages to include
-- `scripts/rag/external-docs-urls.ts` - External URLs to scrape
-- `scripts/rag/code-repositories.ts` - GitHub repositories to index
-
-### Manual Content Addition
-
-For adding custom content programmatically, use the `upsertChunk` mutation:
-
-```typescript
-import { ConvexHttpClient } from "convex/browser";
-import { api } from "./convex/_generated/api";
-import { GoogleGenAI } from "@google/genai";
-
-// Initialize clients
-const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL);
-const genAI = new GoogleGenAI({
-  apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY,
-});
-
-// Generate embedding
-const embeddingResult = await genAI.models.embedContent({
-  model: "text-embedding-004",
-  contents: "Your content text here...",
-});
-const embedding = embeddingResult.embeddings[0].values;
-
-// Add to Convex
-await convex.mutation(api.chunks.upsertChunk, {
-  content: "Your content text here...",
-  embedding: embedding, // 768-dimensional array from text-embedding-004
-  pageTitle: "Page Title",
-  pageUrl: "/path/to/page",
-  section: "Optional Section Name",
-  contentType: "explanation", // or "code", "concept", "example"
-  sourceType: "workshop", // or "docs", "code"
-  contentHash: "unique-hash", // Use crypto.createHash('md5').update(content).digest('hex')
-
-  // Optional fields for code:
-  language: "java",
-  filePath: "src/main/Robot.java",
-  githubUrl: "https://github.com/...",
-
-  // Optional learning metadata:
-  sequencePosition: 1,
-  prerequisites: ["prerequisite-topic"],
-});
-```
-
-### Batch Upload Multiple Chunks
-
-```typescript
-await convex.mutation(api.chunks.upsertChunks, {
-  chunks: [
-    {
-      content: "First chunk...",
-      embedding: [...],
-      pageTitle: "Title 1",
-      pageUrl: "/page1",
-      contentType: "explanation",
-      sourceType: "workshop",
-      contentHash: "hash1",
-    },
-    {
-      content: "Second chunk...",
-      embedding: [...],
-      pageTitle: "Title 2",
-      pageUrl: "/page2",
-      contentType: "code",
-      sourceType: "code",
-      contentHash: "hash2",
-      language: "java",
-    },
-  ],
-});
-```
-
-### Content Schema Fields
-
-| Field              | Type     | Required | Description                                       |
-| ------------------ | -------- | -------- | ------------------------------------------------- |
-| `content`          | string   | ✅       | The actual text content to search                 |
-| `embedding`        | number[] | ✅       | 768-dimensional vector from text-embedding-004    |
-| `pageTitle`        | string   | ✅       | Human-readable page title                         |
-| `pageUrl`          | string   | ✅       | URL path (e.g., "/hardware")                      |
-| `contentType`      | string   | ✅       | "explanation" \| "code" \| "concept" \| "example" |
-| `sourceType`       | string   | ✅       | "workshop" \| "docs" \| "code"                    |
-| `contentHash`      | string   | ✅       | Unique hash for deduplication                     |
-| `section`          | string   | ❌       | Section within the page                           |
-| `language`         | string   | ❌       | Programming language (for code)                   |
-| `filePath`         | string   | ❌       | File path (for code)                              |
-| `githubUrl`        | string   | ❌       | GitHub URL (for code)                             |
-| `sequencePosition` | number   | ❌       | Learning sequence order                           |
-| `prerequisites`    | string[] | ❌       | Required prerequisite topics                      |
-
-### How It Works
-
-1. **Generate embeddings** using Google's text-embedding-004 model (768 dimensions)
-2. **Store content + embedding** in Convex vector database
-3. **AI Assistant searches** using vector similarity when users ask questions
-4. **Retrieved context** is passed to Gemini 2.5 Pro for generating answers
-
-### Checking Stats
-
-Query current database stats:
-
-```typescript
-const stats = await convex.query(api.chunks.getStats);
-console.log(stats);
-// {
-//   totalChunks: 150,
-//   bySourceType: { workshop: 100, docs: 30, code: 20 },
-//   byContentType: { explanation: 80, code: 40, concept: 20, example: 10 },
-//   uniquePages: 25
-// }
-```
-
-## 📝 Content Management
-
-The workshop content is organized into themed pages that can be easily extended:
-
-- Each section has its own route under `/src/app/`
-- Content is written in JSX with Tailwind styling
-- Navigation is automatically generated from the route structure
-- Links between sections provide a guided learning experience
-
-## 🎨 Design Features
-
-- **Responsive Design** - Works on desktop, tablet, and mobile
-- **Clean Typography** - Easy-to-read content with proper hierarchy
-- **Interactive Navigation** - Smooth transitions between sections
-- **Progress Tracking** - Clear next/previous navigation
-- **Code-Friendly** - Optimized for technical content display
-- **Live Code Integration** - Real GitHub repository embedding with PR progression
-- **Video Tutorials** - YouTube integration for visual learning
-- **Interactive Components** - Tabbed interfaces combining code views and PR diffs
-
-## 🔧 Customization
-
-To add new sections:
-
-1. Create a new directory in `src/app/`
-2. Add a `page.tsx` file with your content
-3. Update the navigation in `src/components/Sidebar.tsx`
-4. Link from previous/next pages as needed
-
-## 📱 Mobile Optimization
-
-The site includes:
-
-- Responsive navigation menu
-- Touch-friendly buttons and links
-- Optimized font sizes for mobile reading
-- Fast loading times
+To deploy your own copy, fork the repository and import it at [vercel.com](https://vercel.com).
 
 ## 🤝 Contributing
 
-This project transforms FRC programming workshop content into an interactive learning platform. To contribute:
-
 1. Fork the repository: [https://github.com/Hemlock5712/Workshop-Site](https://github.com/Hemlock5712/Workshop-Site)
 2. Create a feature branch
-3. Make your changes
-4. Run tests and spell check: `pnpm test && pnpm spell`
+3. Make your changes (lesson navigation lives in `src/data/lessons.ts`)
+4. Run `pnpm test && pnpm spell`
 5. Submit a pull request
-
-All contributions help improve the FRC programming education experience!
 
 ## 📄 License
 

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -84,6 +84,7 @@
     "rarr",
     "rdquo",
     "recolouring",
+    "Remotion",
     "reskin",
     "roboRIO",
     "RoboRIO",


### PR DESCRIPTION
## 📋 Description

The README was several rewrites behind the site. It still described the v2-era "5-step subsystem progression," listed PathPlanner as current content, indexed the retired Convex/RAG pipeline (~230 lines), pointed at an `api/gemini/` route that is now `api/chat/`, and showed a project structure predating the `(workshop)`/`(planner)` route groups and `src/data/lessons.ts`.

This PR rewrites it to match reality, keeping it concise as the public front door (CLAUDE.md remains the deep reference):

- **What It Teaches** section: WPILib 2027 alpha stack — Commands v3 + OpModes (`org.wpilib.command3`, `Mechanism`, no `RobotContainer`), Java 25, SystemCore; set-and-hold (`coroutine.park()`) + chaining ending in `.named(...)` as the command conventions; CTRE `DriveToPose`/`LinearPath` for autonomous (explicitly not PathPlanner); `DataLogManager` for logging (not AdvantageKit); 2027-Template as ground truth.
- **Curriculum** mirrors `src/data/lessons.ts` exactly, including utility pages and a note that the `/pathplanner` slug is historical.
- **Project structure** reflects the real tree: route groups, `api/chat` + `api/github`, the unlisted `/video` preview page, the Remotion `videos/` project, and `lessons.ts` called out as the navigation source of truth.
- **AI assistant** section replaces the Convex docs with the actual Gemini File Search setup (`GOOGLE_GENERATIVE_AI_API_KEY` + `GEMINI_FILE_SEARCH_STORE`, the three `scripts/*-file-search.ts` scripts); dropped the `cp .env.example` instruction since that file no longer exists.
- **Commands & stack** verified against `package.json` (Next.js 16 / React 19), with the `generate-search` → `pnpm format` gotcha documented.

Also adds `Remotion` to the cspell dictionary — the only new README word not already covered by CI-spell-checked files.

Net: −429 / +100 lines.

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🎨 Style/UI changes
- [ ] ⚡ Performance improvement
- [ ] ♻️ Code refactoring

## 🧪 Testing

- [x] I have tested my changes locally
- [ ] All CI checks pass (lint, type-check, build)
- [ ] I have verified the Vercel preview deployment

Local verification: Prettier passes on both files (pre-commit lint-staged ran clean). cspell could not run locally (requires Node ≥22.18; machine has 22.15.1), so every distinctive new term was audited instead — each is either in the cspell dictionary or already present in CI-spell-checked files; `Remotion` was the one exception and is added to the dictionary. CI's spell job is the authoritative check.

## 📱 Screenshots (if applicable)

N/A — documentation only, no site changes.

## 📝 Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have updated the documentation if needed

## 🔗 Related Issues

N/A

## 📋 Additional Notes

CLAUDE.md is intentionally untouched. The untracked local `dev/` directory is not part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized and updated the README to reflect the current workshop curriculum, technologies, setup steps, development commands, project structure, AI assistant configuration, deployment, and contribution workflow.
  * Added guidance for the latest robotics software stack and updated lesson topics.
* **Chores**
  * Updated spell-check configuration to recognize “Remotion” as a valid term.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->