### PR TITLE
Stop cspell tripping over YouTube IDs and thumbnail names

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -3,6 +3,7 @@
   "language": "en",
   "useGitignore": true,
   "ignorePaths": ["node_modules", "public", ".next"],
+  "ignoreRegExpList": ["/<VideoEmbed[^>]*?\\bid=\"[A-Za-z0-9_-]{11}\"/g"],
   "words": [
     "ADIS",
     "allwpilib",
@@ -76,6 +77,7 @@
     "holonomic",
     "Holonomic",
     "hotspot",
+    "hqdefault",
     "HTTI",
     "initialises",
     "italicised",
@@ -91,6 +93,7 @@
     "manualstart",
     "marginalium",
     "maxage",
+    "maxresdefault",
     "megatag",
     "minisearch",
     "MiniSearch",


### PR DESCRIPTION
CI has been red on `master` since #107 merged, and PR #108 fails the same way. Both stop at the **Spell check** step with the identical five findings in three files. Everything before it passes and `Build` never runs.

The five split into two kinds.

**Two are real words.** `hqdefault` and `maxresdefault` are YouTube's thumbnail filenames. `VideoEmbed` names both in its doc comment and fetches the second one from `i.ytimg.com`, so they are vocabulary and they go in the word list.

**Three are not words at all.** `aktc`, `Ctcr` and `RBZI` are fragments cspell carved out of the opaque eleven-character video IDs `aktcCtcrEyY` and `7I7r9p1RBZI`. Adding them would mean adding more gibberish every time a lesson gains a video, and it would not be a word list any more. The four IDs already on the site pass only because their fragments happened to look like words, which is luck, not a rule.

So ignore the ID by shape instead, scoped to the one prop that ever holds one:

```
"ignoreRegExpList": ["/<VideoEmbed[^>]*?\bid=\"[A-Za-z0-9_-]{11}\"/g"]
```

Eleven characters of the YouTube alphabet, inside a `VideoEmbed` `id`. Narrow enough that a real typo in a section `id` is still caught, and the next video added trips nothing.

## Verification

- All seven `VideoEmbed` tags match the pattern, including the multi-line one on `/pid-control`.
- `cspell`: **0 issues in 0 files**, across the same 116 files CI checks.
- `pnpm type-check` clean, `pnpm generate-search` clean (185 documents, 33 pages).
- `pnpm build` succeeds. CI never reached this step on `master`, so it was unverified since July 20; it is verified now.

#108 goes green once this lands and it picks up `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated spell-checking configuration to recognize standard video embed identifiers and thumbnail quality terms.
  * Reduced false-positive spelling warnings for supported video content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->